### PR TITLE
Feature: QtObject macro 

### DIFF
--- a/Nim/Examples/SimpleMacro/CMakeLists.txt
+++ b/Nim/Examples/SimpleMacro/CMakeLists.txt
@@ -1,0 +1,2 @@
+file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/main.qml DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+add_nim_executable(TARGET Main SOURCES main.nim PATHS ../../NimQml)

--- a/Nim/Examples/SimpleMacro/main.nim
+++ b/Nim/Examples/SimpleMacro/main.nim
@@ -1,0 +1,57 @@
+## This example replicates the functionality of Examples/Simple but uses
+## the helper macro, QtObject, from NimQmlMacros, to remove some of the boiler plate. 
+## Please note we are using templates where ordinarily we would like to use procedures
+## due to bug: https://github.com/Araq/Nim/issues/1821
+
+import NimQml, NimQmlMacros
+
+QtObject:
+  type MyQObject = ref object of QObject
+    m_name: string
+
+  template newMyQObject(initial: string): MyQObject =
+    var result = MyQObject(m_name: initial)
+    result.create
+    result
+  
+  method getName(myQObject: MyQObject): string {.slot.} =
+    echo "nameChanged"
+    result = myQObject.m_name
+
+  method nameChanged(myQObject: MyQObject) {.signal.}
+  
+  method setName(myQObject: MyQObject, name: string) {.slot.} =
+    echo "setName"
+    if myQObject.m_name != name:
+      myQObject.m_name = name
+      myQObject.nameChanged()
+  
+  QtProperty name of string:
+    read = getName
+    write = setName
+    notify = nameChanged
+
+proc mainProc() =
+  var app: QApplication
+  app.create()
+  defer: app.delete()
+   
+  var myQObject = newMyQObject("InitialName")
+  defer: myQObject.delete() 
+
+  var engine: QQmlApplicationEngine
+  engine.create()
+  defer: engine.delete()
+
+  var variant: QVariant
+  variant.create(myQObject)
+  defer: variant.delete()
+
+  var rootContext: QQmlContext = engine.rootContext()
+  rootContext.setContextProperty("myQObject", variant)
+  engine.load("main.qml")
+  app.exec()
+
+when isMainModule:
+  mainProc()
+

--- a/Nim/Examples/SimpleMacro/main.qml
+++ b/Nim/Examples/SimpleMacro/main.qml
@@ -1,0 +1,36 @@
+import QtQuick 2.2
+import QtQuick.Controls 1.2
+import QtQuick.Layouts 1.1
+import QtQuick.Window 2.1
+
+ApplicationWindow
+{
+	width: 400
+	height: 300
+
+	Component.onCompleted: visible = true
+
+	ColumnLayout
+	{
+	    anchors.fill: parent
+
+	    Label
+	    {
+	        text: "Current name is:" + myQObject.name
+	    }
+
+	    TextField
+	    {
+	        id: textField
+	    }
+
+	    Button
+	    {
+	        text: "Change Name"
+	        onClicked: {
+	            console.log("QML:", textField.text)
+	            myQObject.name = textField.text 
+	        }
+	    }
+	}
+}

--- a/Nim/NimQml/NimQml.nim
+++ b/Nim/NimQml/NimQml.nim
@@ -1,11 +1,13 @@
 import NimQmlTypes
 import tables
+from NimQmlMacros import QtType
 
 export QObject
 export QApplication
 export QVariant
 export QQmlApplicationEngine
 export QQmlContext
+export QtType
 
 type QMetaType* {.pure.} = enum
   UnknownType = cint(0), 

--- a/Nim/NimQml/NimQml.nim
+++ b/Nim/NimQml/NimQml.nim
@@ -1,13 +1,11 @@
 import NimQmlTypes
 import tables
-from NimQmlMacros import QtType
 
 export QObject
 export QApplication
 export QVariant
 export QQmlApplicationEngine
 export QQmlContext
-export QtType
 
 type QMetaType* {.pure.} = enum
   UnknownType = cint(0), 

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -1,0 +1,360 @@
+## Contains helper macros for NimQml
+
+import macros
+import strutils
+import typetraits
+import tables
+
+static:
+  let nimFromQtVariant = {
+    "int" : "intVal",
+    "string" : "stringVal",
+    "bool" : "boolVal" ,
+  }.toTable
+ 
+  let nim2QtMeta = {
+      "bool": "Bool",
+      "int " : "Int",
+      "string" : "QString", 
+      "pointer" : "VoidStar",
+      "QVariant": "QVariant",
+      "" : "Void", # no return, which is represented by an nnkEmpty node
+  }.toTable
+
+proc getNodeOf*(tree: PNimrodNode, kind: TNimrodNodeKind): PNimrodNode {.compileTime.} =
+  ## recursively looks for a node of kind, ``kind``, in the tree provided as ``tree``
+  ## Returnsthe first node that satisfies this condition 
+  for i in 0.. <tree.len:
+    var child = tree[i]
+    if child of PNimrodNode and child.kind == kind:
+      return child
+    var candidate = getNodeOf(child, kind)
+    if not candidate.isNil:
+      return candidate
+
+static:
+  type Context* = ref object of RootObj
+  type NullContext* = ref object of Context  
+
+type NodeModifier*[T] = proc(context: T, a: var PNimrodNode): PNimrodNode
+
+# had to remove type bound on hook due to recent regression with generics
+proc hookOnNode*[T](context: T, code: PNimrodNode, hook: NodeModifier, 
+    recursive: bool = false): PNimrodNode {.compileTime.} =
+  ## Iterates over the tree, ``code``, calling ``hook`` on each ``PNimrodNode``
+  ## encountered. If ``recursive`` is true, it will recurse over the tree, otherwise
+  ## it will only visit ``code``s children. ``hook`` should return a replacement for 
+  ## the node that was passed in via it's return value.
+  if code.len == 0:
+    return code
+  var newCode = newNimNode(code.kind)
+  for i in 0.. <code.len:
+    var child = code[i].copy()
+    child = hook(context, child)
+    if recursive:
+      child = hookOnNode(context,child,hook,true)
+    if child != nil:
+      newCode.add child
+  return newCode
+  
+proc removeOpenSym*(context: NullContext, a: var PNimrodNode): PNimrodNode {.compileTime.} =
+  ## replaces: ``nnkOpenSymChoice`` and ``nnkSym`` nodes with idents corresponding to the
+  ## symbols string representation. 
+  if a.kind == nnkOpenSymChoice: 
+    return ident($a[0].symbol)
+  elif a.kind == nnkSym:
+    return ident($a.symbol)  
+  return a
+  
+proc newTemplate*(name = newEmptyNode(); params: openArray[PNimrodNode] = [newEmptyNode()];  
+    body: PNimrodNode = newStmtList()): PNimrodNode {.compileTime.} =
+  ## shortcut for creating a new template
+  ##
+  ## The ``params`` array must start with the return type of the template, 
+  ## followed by a list of IdentDefs which specify the params.
+  result = newNimNode(nnkTemplateDef).add(
+    name,
+    newEmptyNode(),
+    newEmptyNode(),
+    newNimNode(nnkFormalParams).add(params), ##params
+    newEmptyNode(),  ## pragmas
+    newEmptyNode(),
+    body)
+    
+template declareSuperTemplate*(parent: typedesc, typ: typedesc): typedesc =
+  template superType*(ofType: typedesc[typ]): typedesc[parent] =
+    parent
+
+proc getTypeName*(a: PNimrodNode): PNimrodNode {.compileTime.} =
+  ## returns the node containing the name of an object in a 
+  ## given type definition block 
+  expectMinLen a, 1
+  expectKind a, nnkTypeDef
+  var testee = a
+  if testee[0].kind == nnkPragmaExpr:
+    testee = testee[0]
+  if testee[0].kind in {nnkIdent}:
+    return testee[0]
+  elif testee[0].kind in {nnkPostfix}:
+    return testee[0][1]
+
+proc genSuperTemplate*(typeDecl: PNimrodNode): PNimrodNode {.compileTime.} =
+  ## generates a template, with name: superType, that returns the super type
+  ## of the object defined in the type defintion, ``typeDecl``. ``typeDecl``
+  ## must contain an object inheriting from a base type.
+  expectKind typeDecl, nnkTypeDef
+  let inheritStmt = typeDecl.getNodeOf(nnkOfInherit)
+  let typeName = getTypeName(typeDecl)
+  if inheritStmt == nil: error("you must declare a super type for " & $typeName)
+  # ident of superType (have to deal with generics)
+  let superType = if inheritStmt[0].kind == nnkIdent: inheritStmt[0] else: inheritStmt[0].getNodeOf(nnkIdent)
+  let superTemplate = getAst declareSuperTemplate(superType, typeName) 
+  return superTemplate[0]
+
+proc getSuperType*(typeDecl: PNimrodNode): PNimrodNode {.compileTime.} =
+  ## returns ast containing superType info, may not be an ident if generic
+  let inheritStmt = typeDecl.getNodeOf(nnkOfInherit)
+  if inheritStmt.isNil: return newEmptyNode()
+  return inheritStmt[0]
+
+proc getPragmaName*(child: PNimrodNode): PNimrodNode {.compileTime.} =
+  ## name of child in a nnkPragma section
+  if child.kind == nnkIdent:
+    return child
+  # assumes first ident is name of pragma
+  let ident = child.getNodeOf(nnkIdent)
+  result = ident
+
+proc removePragma*(pragma: PNimrodNode, toRemove: string): PNimrodNode {.compileTime.} =
+  ## removes a pragma from pragma definition, `pragma`, with name `toRemove`
+  expectKind pragma, nnkPragma
+  result = newNimNode(nnkPragma)
+  for i in 0.. <pragma.len:
+    let child = pragma[i]
+    if $child.getPragmaName == toRemove:
+      continue
+    result.add child 
+  if result.len == 0:
+    return newEmptyNode() 
+
+proc hasPragma*(node: PNimrodNode, pragmaName: string): bool {.compileTime.} =
+  ## Returns ``true`` iff the method, or proc definition: ``node``, has a pragma
+  ## ``pragmaName``
+  doAssert node.kind in {nnkMethodDef, nnkProcDef}
+  result = false
+  let pragma = node.pragma
+  if pragma.kind == nnkEmpty:
+    # denotes no pragma set
+    return false
+  for child in pragma.children():
+    if $child.getPragmaName() == pragmaName:
+      return true
+
+proc getArgType*(arg: PNimrodNode): PNimrodNode  {.compileTime.} =
+  ## returns the ``PNimrodNode`` representing a parameters type
+  if arg[1].kind == nnkIdent: 
+    arg[1] 
+  else: 
+    arg[1].getNodeOf(nnkIdent)
+
+proc getArgName*(arg: PNimrodNode): PNimrodNode  {.compileTime.} =
+  ## returns the ``PNimrodNode`` representing a parameters name
+  if arg[0].kind == nnkIdent: 
+    arg[0] 
+  else: 
+    arg[0].getNodeOf(nnkIdent)    
+
+proc addSignalBody(signal: PNimrodNode): PNimrodNode {.compileTime.} =
+  # e.g: produces: emit(MyQObject, "nameChanged")
+  expectKind signal, nnkMethodDef
+  result = newStmtList()
+  # if exported, will use postfix
+  let name = if signal.name.kind == nnkIdent: signal.name else: signal.name[1]
+  let params = signal.params
+  # type signal defined on is the 1st arg
+  let self = getArgName(params[1])
+  var args = newSeq[PNimrodNode]()
+  args.add(self)
+  args.add newLit($name)
+  if params.len > 2: # more args than just type
+    for i in 2.. <params.len:
+      args.add getArgName params[i]
+  result.add newCall("emit", args)
+
+template declareOnSlotCalled(typ: typedesc): stmt =
+  method onSlotCalled(myQObject: typ, slotName: string, args: openarray[QVariant]) =
+    discard
+
+template prototypeCreate(typ: typedesc): stmt =
+  template create(myQObject: var typ) =
+    var super = (typ.superType())(myQObject)
+    procCall create(super)
+
+proc doRemoveOpenSym(a: var PNimrodNode): PNimrodNode {.compileTime.} =
+  hookOnNode(NullContext(),a, removeOpenSym, true)
+
+proc templateBody*(a: PNimrodNode): PNimrodNode {.compileTime.} =
+  expectKind a, nnkTemplateDef
+  result = a[6]
+  
+proc genArgTypeArray(params: PNimrodNode): PNimrodNode {.compileTime.} =
+  expectKind params, nnkFormalParams
+  result = newNimNode(nnkBracket)
+  for i in 0 .. <params.len:
+    if i == 1:
+      # skip "self" param eg: myQObject: MyQObject
+      continue
+    let pType = if i != 0: getArgType params[i] else: params[i]
+    let pTypeString = if pType.kind == nnkEmpty: "" else: $pType
+    # function that maps Qvariant type to nim type
+    let qtMeta = nim2QtMeta[pTypeString]
+    if qtMeta == nil: error(pTypeString & " not supported yet")
+    let metaDot = newDotExpr(ident "QMetaType", ident qtMeta)
+    result.add metaDot
+
+proc getIdentDefName*(a: PNimrodNode): PNimrodNode {.compileTime.} =
+  ## returns object field name from ident def
+  expectKind a, nnkIdentDefs
+  if a[0].kind == nnkIdent:
+    return a[0]
+  elif a[0].kind == nnkPostFix:
+    return a[0][1]
+
+macro QtType*(qtDecl: stmt): stmt {.immediate.} =
+  expectKind(qtDecl, nnkStmtList)
+  #echo treeRepr qtDecl
+  result = newStmtList()
+  var slots = newSeq[PNimrodNode]()
+  var properties = newSeq[PNimrodNode]()
+  var signals = newSeq[PNimrodNode]()
+  # assume only one type per section for now
+  var typ: PNimrodNode
+  for it in qtDecl.children():
+    if it.kind == nnkTypeSection:
+      # add the typesection unchanged
+      let typeDecl = it.findChild(it.kind == nnkTypeDef)
+      let superType = typeDecl.getSuperType()
+      if superType.kind != nnkEmpty:
+        let superName = if superType.kind == nnkIdent: superType else: superType.getNodeOf(nnkIdent)
+        if $superName != "QtProperty":
+          if typ != nil:
+            error("only support one type declaration")
+          typ = typeDecl.getTypeName
+          result.add it
+          result.add genSuperTemplate(typeDecl)
+        else:
+          # process later
+          properties.add(it)
+    elif it.kind == nnkMethodDef:
+      if it.hasPragma("slot"):
+        let pragma = it.pragma()
+        it.pragma = pragma.removePragma("slot")
+        slots.add it # we need to gensome code later
+        result.add it
+      elif it.hasPragma("signal"):
+        let pragma = it.pragma()
+        it.pragma = pragma.removePragma("signal")
+        it.body = addSignalBody(it)
+        result.add it
+        signals.add it
+  
+  ## define onSlotCalled
+  var slotProto = (getAst declareOnSlotCalled(typ))[0]
+  var caseStmt = newNimNode(nnkCaseStmt)
+  caseStmt.add ident("slotName")
+  for slot in slots:
+    var ofBranch = newNimNode(nnkOfBranch)
+    # for exported procedures - strip * marker
+    let slotName = ($slot.name).replace("*","")
+    ofBranch.add newLit slotName
+    let params = slot.params
+    let hasReturn = not (params[0].kind == nnkEmpty)
+    var branchStmts = newStmtList()
+    let paramCount = params.len -1 # don't include ret (arg 0)
+    var args = newSeq[PNimrodNode]()
+    # first params always the object
+    args.add ident "myQObject"
+    for i in 2.. <params.len:
+      let pType = getArgType params[i]
+      # function that maps Qvariant type to nim type
+      let mapper = nimFromQtVariant[$pType]
+      let argAccess = newNimNode(nnkBracketExpr)
+        .add (ident "args")
+        .add newIntLitNode(i-1)
+      let dot = newDotExpr(argAccess, ident mapper)
+      args.add dot
+    var call = newCall(ident slotName, args)
+    if hasReturn:
+      # eg: args[0].strVal = getName(myQObject)
+      let retType = params[0]
+      let mapper = nimFromQtVariant[$retType]
+      let argAccess = newNimNode(nnkBracketExpr)
+        .add (ident "args")
+        .add newIntLitNode(0)
+      let dot = newDotExpr(argAccess, ident mapper)
+      call = newAssignment(dot, call)
+    branchStmts.add call     
+    ofBranch.add branchStmts
+    caseStmt.add ofBranch
+  # add else: discard
+  caseStmt.add newNimNode(nnkElse)
+    .add newStmtList().add newNimNode(nnkDiscardStmt).add newNimNode(nnkEmpty)
+  slotProto.body = newStmtList().add caseStmt
+  result.add slotProto
+
+  # generate create method
+  var createProto = (getAst prototypeCreate(typ))[0]
+  # the template creates loads of openSyms - replace these with idents
+  createProto = doRemoveOpenSym(createProto) 
+  var createBody = createProto.templateBody
+  for slot in slots:
+    let params = slot.params
+    let regSlotDot = newDotExpr(ident "myQObject", ident "registerSlot")
+    let name = ($slot.name).replace("*","")
+    let argTypesArray = genArgTypeArray(params)
+    let call = newCall(regSlotDot, newLit name, argTypesArray)
+    createBody.add call
+  for signal in signals:
+    let params = signal.params
+    let regSigDot = newDotExpr(ident "myQObject", ident "registerSignal")
+    let name = ($signal.name).replace("*","")
+    let argTypesArray = genArgTypeArray(params)
+    let call = newCall(regSigDot, newLit name, argTypesArray)
+    createBody.add call
+  for property in properties:
+    let inherit = property.getNodeOf(nnkOfInherit)
+    # OfInherit
+    #   BracketExpr
+    #     Ident !"QtProperty"
+    #     Ident !"string"
+    let nimPropType = inherit[0][1]
+    let qtPropMeta = nim2QtMeta[$nimPropType]
+    if qtPropMeta == nil: error($nimPropType & " not supported")
+    let metaDot = newDotExpr(ident "QMetaType", ident qtPropMeta) 
+    let typeDef = property.getNodeOf(nnkTypeDef)
+    let typeName = typeDef.getTypeName()
+    var read, write, notify: PNimrodNode
+    # fields
+    let recList = typeDef.getNodeof(nnkRecList)
+    for identDef in recList.children:
+      let name = identDef.getIdentDefName()
+      case $name
+      of "read":
+        read = identDef[2]
+      of "write":
+        write = identDef[2]
+      of "notify":
+        notify = identDef[2]
+      else:
+        error("unknown property field: " & $name) 
+    let regPropDot = newDotExpr(ident "myQObject", ident "registerProperty")
+    let readArg = if read == nil: newNilLit() else: newLit($read)
+    let writeArg = if write == nil: newNilLit() else: newLit($write)
+    let notifyArg = if notify == nil: newNilLit() else: newLit($notify)
+    let call = newCall(regPropDot, newLit($typeName), metaDot, readArg, writeArg, notifyArg)
+    createBody.add call
+
+  #echo repr createProto
+  result.add createProto
+  when not defined(release):
+    echo repr result

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -364,7 +364,6 @@ macro QtObject*(qtDecl: stmt): stmt {.immediate.} =
     #     Ident !"read"
     #     Ident !"getName
     for asgn in stmtList.children:
-      echo treerepr asgn
       let name = asgn[0]
       case $name
       of "read":

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -13,25 +13,21 @@ template debug(body: stmt): stmt =
   else:
     {.pop.}
 
-# these are defined in a template to work around a compiler bug
-# with {.compileTime.}/static variables not being "computable at
-# compile time" when a macro using them is imported into another
-# module
-template defineMappings =
-  let nimFromQtVariant {.inject.} = {
-    "int" : "intVal",
-    "string" : "stringVal",
-    "bool" : "boolVal" ,
-  }.toTable
- 
-  let nim2QtMeta {.inject.} = {
-      "bool": "Bool",
-      "int " : "Int",
-      "string" : "QString", 
-      "pointer" : "VoidStar",
-      "QVariant": "QVariant",
-      "" : "Void", # no return, which is represented by an nnkEmpty node
-  }.toTable
+
+let nimFromQtVariant {.compileTime.} = {
+  "int" : "intVal",
+  "string" : "stringVal",
+  "bool" : "boolVal",
+}.toTable
+
+let nim2QtMeta {.compileTime.} = {
+    "bool": "Bool",
+    "int " : "Int",
+    "string" : "QString",
+    "pointer" : "VoidStar",
+    "QVariant": "QVariant",
+    "" : "Void", # no return, which is represented by an nnkEmpty node
+}.toTable
 
 proc getNodeOf*(tree: PNimrodNode, kind: TNimrodNodeKind): PNimrodNode {.compileTime.} =
   ## recursively looks for a node of kind, ``kind``, in the tree provided as ``tree``
@@ -210,7 +206,6 @@ proc templateBody*(a: PNimrodNode): PNimrodNode {.compileTime.} =
   result = a[6]
   
 proc genArgTypeArray(params: PNimrodNode): PNimrodNode {.compileTime.} =
-  defineMappings
   expectKind params, nnkFormalParams
   result = newNimNode(nnkBracket)
   for i in 0 .. <params.len:
@@ -234,7 +229,6 @@ proc getIdentDefName*(a: PNimrodNode): PNimrodNode {.compileTime.} =
     return a[0][1]
 
 macro QtType*(qtDecl: stmt): stmt {.immediate.} =
-  defineMappings
   expectKind(qtDecl, nnkStmtList)
   #echo treeRepr qtDecl
   result = newStmtList()

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -227,7 +227,7 @@ proc getIdentDefName*(a: PNimrodNode): PNimrodNode {.compileTime.} =
   elif a[0].kind == nnkPostFix:
     return a[0][1]
 
-macro QtType*(qtDecl: stmt): stmt {.immediate.} =
+macro QtObject*(qtDecl: stmt): stmt {.immediate.} =
   expectKind(qtDecl, nnkStmtList)
   #echo treeRepr qtDecl
   result = newStmtList()

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -5,14 +5,18 @@ import strutils
 import typetraits
 import tables
 
-static:
-  let nimFromQtVariant = {
+# these are defined in a template to work around a compiler bug
+# with {.compileTime.}/static variables not being "computable at
+# compile time" when a macro using them is imported into another
+# module
+template defineMappings =
+  let nimFromQtVariant {.inject.} = {
     "int" : "intVal",
     "string" : "stringVal",
     "bool" : "boolVal" ,
   }.toTable
  
-  let nim2QtMeta = {
+  let nim2QtMeta {.inject.} = {
       "bool": "Bool",
       "int " : "Int",
       "string" : "QString", 
@@ -198,6 +202,7 @@ proc templateBody*(a: PNimrodNode): PNimrodNode {.compileTime.} =
   result = a[6]
   
 proc genArgTypeArray(params: PNimrodNode): PNimrodNode {.compileTime.} =
+  defineMappings
   expectKind params, nnkFormalParams
   result = newNimNode(nnkBracket)
   for i in 0 .. <params.len:
@@ -221,6 +226,7 @@ proc getIdentDefName*(a: PNimrodNode): PNimrodNode {.compileTime.} =
     return a[0][1]
 
 macro QtType*(qtDecl: stmt): stmt {.immediate.} =
+  defineMappings
   expectKind(qtDecl, nnkStmtList)
   #echo treeRepr qtDecl
   result = newStmtList()

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -13,7 +13,6 @@ template debug(body: stmt): stmt =
   else:
     {.pop.}
 
-
 let nimFromQtVariant {.compileTime.} = {
   "int" : "intVal",
   "string" : "stringVal",
@@ -235,6 +234,8 @@ macro QtType*(qtDecl: stmt): stmt {.immediate.} =
   var slots = newSeq[PNimrodNode]()
   var properties = newSeq[PNimrodNode]()
   var signals = newSeq[PNimrodNode]()
+  # holds all user defined procedures so we can add them after create
+  var userDefined = newSeq[PNimrodNode]()
   # assume only one type per section for now
   var typ: PNimrodNode
   for it in qtDecl.children():
@@ -267,6 +268,10 @@ macro QtType*(qtDecl: stmt): stmt {.immediate.} =
         it.body = addSignalBody(it)
         result.add it
         signals.add it
+      else:
+        userDefined.add it
+    elif it.kind == nnkProcDef:
+      userDefined.add it
     else:
       # everything else should pass through unchanged
       result.add it
@@ -368,5 +373,9 @@ macro QtType*(qtDecl: stmt): stmt {.immediate.} =
 
   #echo repr createProto
   result.add createProto
+
+  for fn in userDefined:
+    result.add fn
+
   debug:
     echo repr result


### PR DESCRIPTION
Here is the initial attempt at adding the QtObject macro. It should provide a stepping stone for adding additional functionality and finding any possible bugs. I thought it would be a good idea to require users to explicitly import ``QmlMacros`` (i.e not export from NimQml) until we declare it stable.