### PR TITLE
Only export generated methods when the object declared within the macro body is exported

### DIFF
--- a/Nim/Examples/QtObjectMacro/Contact.nim
+++ b/Nim/Examples/QtObjectMacro/Contact.nim
@@ -3,7 +3,7 @@
 import NimQml, NimQmlMacros
 
 QtObject:
-  type Contact = ref object of QObject
+  type Contact* = ref object of QObject
     m_name: string
 
   template newContact*(): Contact =

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -90,8 +90,9 @@ proc newTemplate*(name = newEmptyNode();
     newEmptyNode(),  ## pragmas
     newEmptyNode(),
     body)
-    
-template declareSuperTemplate*(parent: typedesc, typ: typedesc): typedesc =
+
+#FIXME: changed parent, typ from typedesc to expr to workaround Nim issue #1874    
+template declareSuperTemplate*(parent: expr, typ: expr): stmt =
   template superType*(ofType: typedesc[typ]): typedesc[parent] =
     parent
 
@@ -192,11 +193,13 @@ proc addSignalBody(signal: PNimrodNode): PNimrodNode {.compileTime.} =
       args.add getArgName params[i]
   result.add newCall("emit", args)
 
-template declareOnSlotCalled(typ: typedesc): stmt =
+#FIXME: changed typ from typedesc to expr to workaround Nim issue #1874 
+template declareOnSlotCalled(typ: expr): stmt =
   method onSlotCalled(myQObject: typ, slotName: string, args: openarray[QVariant]) =
     discard
 
-template prototypeCreate(typ: typedesc): stmt =
+#FIXME: changed parent, typ from typedesc to expr to workaround Nim issue #1874 
+template prototypeCreate(typ: expr): stmt =
   template create*(myQObject: var typ) =
     var super = (typ.superType())(myQObject)
     procCall create(super)


### PR DESCRIPTION
Edit: I have submitted an alternative to this in #4 with a change to the macro syntax

This also includes a workaround for Araq/Nim#1874 as the code no longer compiled with the latest devel Nim. Like you say, if create becomes a method we could require an explicit export with:

```nimrod
export create
```

instead of automatically exporting it. I guess `superType` is always useful though.
