### PR TITLE
Change macro syntax

### DIFF
--- a/Nim/Docs/NimQml.txt
+++ b/Nim/Docs/NimQml.txt
@@ -231,5 +231,5 @@ In details:
 The ``QtProperty`` macro has the following syntax
 
 .. code-block:: nim
-  QtProperty nameOfProperty of typeOfProperty
+  QtProperty[typeOfProperty] nameOfProperty
 

--- a/Nim/Examples/QtObjectMacro/Contact.nim
+++ b/Nim/Examples/QtObjectMacro/Contact.nim
@@ -3,7 +3,7 @@
 import NimQml, NimQmlMacros
 
 QtObject:
-  type Contact = ref object of QObject
+  type Contact* = ref object of QObject
     m_name: string
 
   template newContact*(): Contact =

--- a/Nim/Examples/QtObjectMacro/Contact.nim
+++ b/Nim/Examples/QtObjectMacro/Contact.nim
@@ -21,7 +21,7 @@ QtObject:
       contact.m_name = name
       contact.nameChanged()
   
-  QtProperty name of string:
+  QtProperty[string] name:
     read = getName
     write = setName
     notify = nameChanged

--- a/Nim/NimQml/NimQmlMacros.nim
+++ b/Nim/NimQml/NimQmlMacros.nim
@@ -90,8 +90,9 @@ proc newTemplate*(name = newEmptyNode();
     newEmptyNode(),  ## pragmas
     newEmptyNode(),
     body)
-    
-template declareSuperTemplate*(parent: typedesc, typ: typedesc): typedesc =
+
+#FIXME: changed parent, typ from typedesc to expr to workaround Nim issue #1874    
+template declareSuperTemplate*(parent: expr, typ: expr): stmt =
   template superType*(ofType: typedesc[typ]): typedesc[parent] =
     parent
 
@@ -192,11 +193,13 @@ proc addSignalBody(signal: PNimrodNode): PNimrodNode {.compileTime.} =
       args.add getArgName params[i]
   result.add newCall("emit", args)
 
-template declareOnSlotCalled(typ: typedesc): stmt =
+#FIXME: changed typ from typedesc to expr to workaround Nim issue #1874 
+template declareOnSlotCalled(typ: expr): stmt =
   method onSlotCalled(myQObject: typ, slotName: string, args: openarray[QVariant]) =
     discard
 
-template prototypeCreate(typ: typedesc): stmt =
+#FIXME: changed parent, typ from typedesc to expr to workaround Nim issue #1874 
+template prototypeCreate(typ: expr): stmt =
   template create*(myQObject: var typ) =
     var super = (typ.superType())(myQObject)
     procCall create(super)


### PR DESCRIPTION
As this was a simple change, I thought I'd implement it and let you decide which version was best. The syntax becomes:

```nimrod
QtProperty[typeName] propertyName:
  read: readMethod
  write: writeMethod
  notify: notifyMethod
```
The only thing I disliked about the `of` syntax was that it looked like `of` was acting on `typeName` and `propertyName`. E.g with:

```nimrod
QtProperty name of string:
  read: readMethod
  write: writeMethod
  notify: notifyMethod
```
I'd think name was a string. The changed syntax makes it clearer, at least to me, that typeName is associated with QtProperty. The choice is yours... :smile:

This is an alternative to #3