### PR TITLE
Assorted fixes 

### DIFF
--- a/Nim/NimQml/NimQml.nim
+++ b/Nim/NimQml/NimQml.nim
@@ -249,9 +249,7 @@ proc registerProperty*(qobject: var QObject,
 proc emit*(qobject: QObject, signalName: string, args: openarray[QVariant] = []) =
   ## Emit the signal with the given name and values
   if args.len > 0: 
-    var copy: seq[QVariant]
-    for i in 0..args.len-1:
-      copy.add(args[i])
+    var copy = @args
     dos_qobject_signal_emit(qobject.data, signalName, args.len.cint, addr(copy[0]))
   else:
     dos_qobject_signal_emit(qobject.data, signalName, 0, nil)

--- a/Nim/NimQml/NimQml.nim
+++ b/Nim/NimQml/NimQml.nim
@@ -90,11 +90,11 @@ proc intVal*(variant: QVariant): int =
   ## Return the QVariant value as int
   var rawValue: cint
   dos_qvariant_toInt(variant, rawValue)
-  result = cast[int](rawValue)
+  result = rawValue.cint
 
 proc `intVal=`*(variant: QVariant, value: int) = 
   ## Sets the QVariant value int value
-  var rawValue = cast[cint](value)
+  var rawValue = value.cint
   dos_qvariant_setInt(variant, rawValue)
 
 proc boolVal*(variant: QVariant): bool = 
@@ -215,36 +215,36 @@ proc delete*(qobject: QObject) =
   qobjectRegistry.del qobjectPtr
   dos_qobject_delete(qobject.data)
 
-proc registerSlot*(qobject: var QObject, 
+proc registerSlot*(qobject: QObject,
                    slotName: string, 
                    metaTypes: openarray[QMetaType]) =
   ## Register a slot in the QObject with the given name and signature
   # Copy the metatypes array
   var copy = toCIntSeq(metatypes)
   var index: cint 
-  dos_qobject_slot_create(qobject.data, slotName, cint(copy.len), cast[ptr cint](addr(copy[0])), index)
+  dos_qobject_slot_create(qobject.data, slotName, cint(copy.len), addr(copy[0].cint), index)
   qobject.slots[slotName] = index
 
-proc registerSignal*(qobject: var QObject, 
+proc registerSignal*(qobject: QObject,
                      signalName: string, 
                      metatypes: openarray[QMetaType]) =
   ## Register a signal in the QObject with the given name and signature
   var index: cint 
   if metatypes.len > 0:
     var copy = toCIntSeq(metatypes)
-    dos_qobject_signal_create(qobject.data, signalName, cast[cint](copy.len), cast[ptr cint](addr(copy[0])), index)
+    dos_qobject_signal_create(qobject.data, signalName, copy.len.cint, addr(copy[0].cint), index)
   else:
-    dos_qobject_signal_create(qobject.data, signalName, 0, cast[ptr cint](0), index)
+    dos_qobject_signal_create(qobject.data, signalName, 0, nil, index)
   qobject.signals[signalName] = index
 
-proc registerProperty*(qobject: var QObject, 
+proc registerProperty*(qobject: QObject,
                        propertyName: string, 
                        propertyType: QMetaType, 
                        readSlot: string, 
                        writeSlot: string, 
                        notifySignal: string) =
   ## Register a property in the QObject with the given name and type.
-  dos_qobject_property_create(qobject.data, propertyName, cast[cint](propertyType), readSlot, writeSlot, notifySignal)
+  dos_qobject_property_create(qobject.data, propertyName, propertyType.cint, readSlot, writeSlot, notifySignal)
 
 proc emit*(qobject: QObject, signalName: string, args: openarray[QVariant] = []) =
   ## Emit the signal with the given name and values

--- a/Nim/NimQml/NimQmlTypes.nim
+++ b/Nim/NimQml/NimQmlTypes.nim
@@ -7,10 +7,11 @@ type
   QApplication* = distinct pointer ## A QApplication
   DynamicQObject* = distinct pointer
     ## internal representation of a QObject, as recognised by DOtherSide
-  QObject* {.inheritable.} = ref object of RootObj ## A QObject
+  QObjectObj* = object of RootObj ## A QObject
     name*: string
     data*: DynamicQObject
     slots*: Table[string, cint]
     signals*: Table[string, cint]
     properties*: Table[string, cint]
+  QObject* = ref QObjectObj
   QQuickView* = distinct pointer ## A QQuickView


### PR DESCRIPTION
The main change is that we no longer pass DOtherSide a pointer to a reference. This is because the actual reference only exists in the stack frame it is created in (the object it points to lives on). This was a problem as when we were creating a reference in a constructor procedure, it was going out of scope ( hence the need for templates instead). We now keep a internal reference to the QObjectObj (to keep it alive) and pass a pointer the the QObjectObj to DOtherSide instead.

Nim's cast is analogous to c++'s reinterpret_cast, so I changed them to type conversions instead (static_cast)