### PR TITLE
feature/constructors

### DIFF
--- a/Nim/Examples/HelloWorld/main.nim
+++ b/Nim/Examples/HelloWorld/main.nim
@@ -3,12 +3,10 @@ import macros
 import typeinfo
 
 proc mainProc() =
-  var app: QApplication
-  app.create()
+  let app = newQApplication()
   defer: app.delete()
    
-  var engine: QQmlApplicationEngine
-  engine.create()
+  let engine = newQQmlApplicationEngine()
   defer: engine.delete()
 
   engine.load("main.qml")

--- a/Nim/Examples/QtObjectMacro/Contact.nim
+++ b/Nim/Examples/QtObjectMacro/Contact.nim
@@ -1,15 +1,12 @@
-## Please note we are using templates where ordinarily we would like to use procedures
-## due to bug: https://github.com/Araq/Nim/issues/1821
 import NimQml, NimQmlMacros
 
 QtObject:
   type Contact* = ref object of QObject
     m_name: string
 
-  template newContact*(): Contact =
-    var result = Contact(m_name: "initialName")
+  proc newContact*(): Contact =
+    result = Contact(m_name: "initialName")
     result.create
-    result
   
   method getName*(contact: Contact): string {.slot.} =
     result = contact.m_name

--- a/Nim/Examples/QtObjectMacro/main.nim
+++ b/Nim/Examples/QtObjectMacro/main.nim
@@ -2,22 +2,19 @@ import NimQml
 import Contact
 
 proc mainProc() =
-  var app: QApplication
-  app.create()
+  let app = newQApplication()
   defer: app.delete()
    
-  var contact = newContact()
+  let contact = newContact()
   defer: contact.delete() 
 
-  var engine: QQmlApplicationEngine
-  engine.create()
+  let engine = newQQmlApplicationEngine()
   defer: engine.delete()
 
-  var variant: QVariant
-  variant.create(contact)
+  let variant = newQVariant(contact)
   defer: variant.delete()
 
-  var rootContext: QQmlContext = engine.rootContext()
+  let rootContext: QQmlContext = engine.rootContext()
   rootContext.setContextProperty("contact", variant)
   engine.load("main.qml")
   app.exec()

--- a/Nim/Examples/SimpleData/main.nim
+++ b/Nim/Examples/SimpleData/main.nim
@@ -3,32 +3,24 @@ import macros
 import typeinfo
 
 proc mainProc() =
-  var app: QApplication
-  app.create()
+  let app = newQApplication()
   defer: app.delete()
    
-  var engine: QQmlApplicationEngine
-  engine.create()
+  let engine = newQQmlApplicationEngine()
   defer: engine.delete()
 
-  var qVar1: QVariant
-  qVar1.create()
+  let qVar1 = newQVariant(10)
   defer: qVar1.delete()
-  qVar1.intVal = 10
 
-  var qVar2: QVariant
-  qVar2.create()
+  let qVar2 = newQVariant("Hello World")
   defer: qVar2.delete()
-  qVar2.stringVal = "Hello World"
 
-  var qVar3: QVariant
-  qVar3.create()
+  let qVar3 = newQVariant(false)
   defer: qVar3.delete()
-  qVar3.boolVal = false
   
   engine.rootContext.setContextProperty("qVar1", qVar1) 
   engine.rootContext.setContextProperty("qVar2", qVar2)
-  engine.rootContext.setContextProperty("qVar3", qVar2)
+  engine.rootContext.setContextProperty("qVar3", qVar3)
   
   engine.load("main.qml")
   app.exec()

--- a/Nim/Examples/SlotsAndProperties/Contact.nim
+++ b/Nim/Examples/SlotsAndProperties/Contact.nim
@@ -1,19 +1,16 @@
-## Please note we are using templates where ordinarily we would like to use procedures
-## due to bug: https://github.com/Araq/Nim/issues/1821
 import NimQml
 
 type Contact = ref object of QObject 
   m_name: string
   
-template newContact*(): Contact = 
-  var result = Contact(m_name: "initialName")
+proc newContact*(): Contact =
+  result = Contact(m_name: "initialName")
   result.create()
   result.m_name = "InitialName"
   result.registerSlot("getName", [QMetaType.QString])
   result.registerSlot("setName", [QMetaType.Void, QMetaType.QString])
   result.registerSignal("nameChanged", [QMetaType.Void])
   result.registerProperty("name", QMetaType.QString, "getName", "setName", "nameChanged")
-  result
 
 method getName*(self: Contact): string =
   result = self.m_name

--- a/Nim/Examples/SlotsAndProperties/main.nim
+++ b/Nim/Examples/SlotsAndProperties/main.nim
@@ -2,22 +2,19 @@ import NimQml
 import Contact
 
 proc mainProc() =
-  var app: QApplication
-  app.create()
+  let app = newQApplication()
   defer: app.delete()
    
-  var contact = newContact()
+  let contact = newContact()
   defer: contact.delete() 
   
-  var engine: QQmlApplicationEngine
-  engine.create()
+  let engine = newQQmlApplicationEngine()
   defer: engine.delete()
 
-  var variant: QVariant
-  variant.create(contact)
+  let variant = newQVariant(contact)
   defer: variant.delete()
 
-  var rootContext: QQmlContext = engine.rootContext()
+  let rootContext: QQmlContext = engine.rootContext()
   rootContext.setContextProperty("contact", variant)
   engine.load("main.qml")
   app.exec()

--- a/Nim/NimQml/NimQml.nim
+++ b/Nim/NimQml/NimQml.nim
@@ -57,6 +57,7 @@ proc dos_qvariant_setBool(variant: QVariant, value: bool) {.cdecl, dynlib:"libDO
 proc dos_qvariant_setString(variant: QVariant, value: cstring) {.cdecl, dynlib:"libDOtherSide.so", importc.}
 proc dos_chararray_delete(rawCString: cstring) {.cdecl, dynlib:"libDOtherSide.so", importc.}
 
+
 proc create*(variant: var QVariant) =
   ## Create a new QVariant
   dos_qvariant_create(variant)
@@ -117,6 +118,22 @@ proc `stringVal=`*(variant: QVariant, value: string) =
   ## Sets the QVariant string value
   dos_qvariant_setString(variant, value)
 
+proc newQVariant*(stringVal: string): QVariant =
+  ## Create a new QVariant given a string value
+  result.create(stringVal)
+
+proc newQVariant*(boolVal: bool): QVariant =
+  ## Create a new QVariant given a bool value
+  result.create(boolVal)
+
+proc newQVariant*(intVal: int): QVariant =
+  ## Create a new QVariant given a cint value
+  result.create(intval.cint)
+
+proc newQVariant*(qobject: QObject): QVariant =
+  ## Create a new QVariant given a QObject
+  result.create(qobject)
+
 
 # QQmlApplicationEngine
 proc dos_qqmlapplicationengine_create(engine: var QQmlApplicationEngine) {.cdecl, dynlib:"libDOtherSide.so", importc.}
@@ -141,6 +158,10 @@ proc delete*(engine: QQmlApplicationEngine) =
   debugMsg("QQmlApplicationEngine", "delete")
   dos_qqmlapplicationengine_delete(engine)
 
+proc newQQmlApplicationEngine*(): QQmlApplicationEngine =
+  ## Create an new QQmlApplicationEngine
+  result.create
+
 # QQmlContext
 proc dos_qqmlcontext_setcontextproperty(context: QQmlContext, propertyName: cstring, propertyValue: QVariant) {.cdecl, dynlib:"libDOtherSide.so", importc.}
 
@@ -164,6 +185,10 @@ proc exec*(application: QApplication) =
 proc delete*(application: QApplication) = 
   ## Delete the given QApplication
   dos_qguiapplication_delete()
+
+proc newQApplication*(): QApplication =
+  ## Create a new QApplication
+  result.create
 
 # QObject
 type QVariantArray {.unchecked.} = array[0..0, QVariant]
@@ -191,7 +216,7 @@ proc dos_qobject_property_create(qobject: DynamicQObject, propertyName: cstring,
 method onSlotCalled*(nimobject: QObject, slotName: string, args: openarray[QVariant]) =
   ## Called from the NimQml bridge when a slot is called from Qml.
   ## Subclasses can override the given method for handling the slot call
-  discard()
+  discard
 
 proc qobjectCallback(nimobject: ptr QObjectObj, slotName: QVariant, numArguments: cint, arguments: QVariantArrayPtr) {.cdecl, exportc.} =
   let qobject = qobjectRegistry[nimobject]
@@ -282,3 +307,6 @@ proc delete(view: QQuickView) =
   ## Delete the given QQuickView
   dos_qquickview_delete(view)
 
+proc newQQuickView*(): QQuickView =
+  # constructs a new QQuickView
+  result.create


### PR DESCRIPTION
Adds some constructors so you can initialise some common objects in one line. 

Just realised this depends on the change to `QObject.create` in #8 as I changed the templates to procedures. 

If this is adopted, it may be worth deprecating the create procedures with `{.deprecated.}` so they can be unexported in the future