### PR TITLE
addLibraryPath

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -16,6 +16,8 @@ extern "C"
 
 // QCoreApplication
 DOS_API void dos_qcoreapplication_application_dir_path(char** result);
+DOS_API void dos_qcoreapplication_add_library_path(const char* path);
+
 
 // QGuiApplication
 DOS_API void dos_qguiapplication_create();

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -31,7 +31,7 @@ void dos_qcoreapplication_application_dir_path(char** result)
 
 void dos_qcoreapplication_add_library_path(const char* path)
 {
-	        QCoreApplication::addLibraryPath(QString(path));
+    QCoreApplication::addLibraryPath(QString(path));
 }
 
 

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -29,6 +29,12 @@ void dos_qcoreapplication_application_dir_path(char** result)
     convert_to_cstring(QCoreApplication::applicationDirPath(), result);
 }
 
+void dos_qcoreapplication_add_library_path(const char* path)
+{
+	        QCoreApplication::addLibraryPath(QString(path));
+}
+
+
 void dos_qguiapplication_create()
 {
     static int argc = 1;


### PR DESCRIPTION
This seems to be needed in order to build and run dqml applications on arch linux.
