### PR TITLE
Expose sendPostedEvents and processEvents

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -73,6 +73,21 @@ DOS_API void DOS_CALL dos_qapplication_quit();
 /// \note A QApplication should have been already created through dos_qapplication_create()
 DOS_API void DOS_CALL dos_qapplication_delete();
 
+/// \brief Calls the QCoreApplication::processEvents() of the current QGuiApplication
+/// Processes all pending events for the calling thread according to the specified flags
+/// until there are no more events to process.
+/// You can call this function occasionally when your program is busy performing a long
+/// operation (e.g. copying a file).
+/// \note A QApplication should have been already created through dos_qapplication_create()
+DOS_API void DOS_CALL dos_qapplication_process_events();
+
+/// \brief Calls the QCoreApplication::sendPostedEvents() of the current QGuiApplication
+/// Immediately dispatches all events which have been previously queued with
+/// QCoreApplication::postEvent().
+/// Events from the window system are not dispatched by this function, but by process_events().
+/// \note A QApplication should have been already created through dos_qapplication_create()
+DOS_API void DOS_CALL dos_qapplication_send_posted_events();
+
 /// @}
 
 /// \defgroup QQmlApplicationEngine QQmlApplicationEngine

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -82,6 +82,16 @@ void dos_qapplication_quit()
     qApp->quit();
 }
 
+void dos_qapplication_process_events()
+{
+    qApp->processEvents();
+}
+
+void dos_qapplication_send_posted_events()
+{
+    qApp->sendPostedEvents();
+}
+
 ::DosQQmlApplicationEngine *dos_qqmlapplicationengine_create()
 {
     return new QQmlApplicationEngine();


### PR DESCRIPTION
Exposing sendPostedEvents and processEvents allows users of DOtherSide to spin the event loop manually to prevent locking up the application during long running functions in the main thread.