### PR TITLE
Use qGuiApp instead of qApp when working with a QGuiApplication

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -46,17 +46,17 @@ void dos_qguiapplication_create()
 
 void dos_qguiapplication_delete()
 {
-    delete qApp;
+    delete qGuiApp;
 }
 
 void dos_qguiapplication_exec()
 {
-    qApp->exec();
+    qGuiApp->exec();
 }
 
 void dos_qguiapplication_quit()
 {
-    qApp->quit();
+    qGuiApp->quit();
 }
 
 void dos_qapplication_create()


### PR DESCRIPTION
qApp casts to QApplication, so it is only really valid when we're using
QApplication. In addition, QApplication and qApp are part of QtWidgets,
so using qApp adds an unnecessary dependency on QtWidgets to
QtQuick-only applications.