### PR TITLE
QAbstractItemModel::hasIndex added.

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -469,6 +469,9 @@ DOS_API DosQVariant *DOS_CALL dos_qabstractitemmodel_headerData(DosQAbstractItem
 /// \brief Calls the QAbstractItemModel::hasChildren function
 DOS_API bool DOS_CALL dos_qabstractitemmodel_hasChildren(DosQAbstractItemModel *vptr, DosQModelIndex *parentIndex);
 
+/// \breif Calls the QAbstractItemModel::hasIndex function
+DOS_API bool DOS_CALL dos_qabstractitemmodel_hasIndex(DosQAbstractItemModel *vptr, int row, int column, DosQModelIndex *dosParentIndex);
+
 /// \brief Calls the QAbstractItemModel::canFetchMore function
 DOS_API bool DOS_CALL dos_qabstractitemmodel_canFetchMore(DosQAbstractItemModel *vptr, DosQModelIndex *parentIndex);
 

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -119,6 +119,9 @@ typedef void (DOS_CALL *ParentCallback)(void *self, const DosQModelIndex *child,
 /// Called when the QAbstractItemModel::hasChildren method must be called
 typedef void (DOS_CALL *HasChildrenCallback)(void *self, const DosQModelIndex *parent, bool *result);
 
+/// Called when the QAbstractItemModel::hasIndex method must be called
+typedef void (DOS_CALL *HasIndexCallback)(void *self, int row, int column, const DosQModelIndex *parent, bool *result);
+
 /// Called when the QAbstractItemModel::canFetchMore method must be called
 typedef void (DOS_CALL *CanFetchMoreCallback)(void *self, const DosQModelIndex *parent, bool *result);
 
@@ -330,6 +333,7 @@ struct DosQAbstractItemModelCallbacks {
     IndexCallback index;
     ParentCallback parent;
     HasChildrenCallback hasChildren;
+    HasIndexCallback hasIndex;
     CanFetchMoreCallback canFetchMore;
     FetchMoreCallback fetchMore;
 };

--- a/lib/include/DOtherSide/DosIQAbstractItemModelImpl.h
+++ b/lib/include/DOtherSide/DosIQAbstractItemModelImpl.h
@@ -68,6 +68,9 @@ public:
     /// @see QAbstractItemModel::hasChildren
     virtual bool defaultHasChildren(const QModelIndex &parent) const = 0;
 
+    /// @see QAbstractItemModel::hasIndex
+    virtual bool defaultHasIndex(int row, int column, const QModelIndex &parent) const = 0;
+
     /// @see QAbstractItemModel::canFetchMore
     virtual bool defaultCanFetchMore(const QModelIndex &parent) const = 0;
 

--- a/lib/include/DOtherSide/DosQAbstractItemModel.h
+++ b/lib/include/DOtherSide/DosQAbstractItemModel.h
@@ -114,6 +114,9 @@ public:
     /// Expose the hasChildren
     bool hasChildren(const QModelIndex &parent = QModelIndex()) const override;
 
+    /// Expose hasIndex
+    bool hasIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;// override;
+
     /// Expose the canFetchMore
     bool canFetchMore(const QModelIndex &parent) const override;
 
@@ -142,6 +145,7 @@ public:
 
     using DosQAbstractGenericModel::DosQAbstractGenericModel;
     bool defaultHasChildren(const QModelIndex &parent) const override;
+    bool defaultHasIndex(int row, int column, const QModelIndex &parent) const override;
 };
 
 class DosQAbstractTableModel : public DosQAbstractGenericModel<QAbstractTableModel>
@@ -155,6 +159,12 @@ public:
     QModelIndex defaultParent(const QModelIndex &child) const;
     QModelIndex defaultIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;
     bool defaultHasChildren(const QModelIndex &parent) const override;
+private:
+    bool defaultHasIndex(int row, int column, const QModelIndex &parent) const override
+    {
+        // do nothing
+        return false;
+    }
 };
 
 class DosQAbstractListModel : public DosQAbstractGenericModel<QAbstractListModel>
@@ -169,6 +179,12 @@ public:
     QModelIndex defaultIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;
     int defaultColumnCount(const QModelIndex &parent) const;
     bool defaultHasChildren(const QModelIndex &parent) const override;
+private:
+    bool defaultHasIndex(int row, int column, const QModelIndex &parent) const override
+    {
+        // do nothing
+        return false;
+    }
 };
 
 } // namespace DOS

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -846,6 +846,14 @@ bool dos_qabstractitemmodel_hasChildren(DosQAbstractItemModel *vptr, DosQModelIn
     return model->defaultHasChildren(*parentIndex);
 }
 
+bool dos_qabstractitemmodel_hasIndex(DosQAbstractItemModel *vptr, int row, int column, DosQModelIndex *dosParentIndex)
+{
+    auto object = static_cast<QObject *>(vptr);
+    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
+    auto parentIndex = static_cast<QModelIndex *>(dosParentIndex);
+    return model->defaultHasIndex(row, column, *parentIndex);
+}
+
 bool dos_qabstractitemmodel_canFetchMore(DosQAbstractItemModel *vptr, DosQModelIndex *dosParentIndex)
 {
     auto object = static_cast<QObject *>(vptr);

--- a/lib/src/DosQAbstractItemModel.cpp
+++ b/lib/src/DosQAbstractItemModel.cpp
@@ -228,6 +228,14 @@ bool DosQAbstractGenericModel<T>::hasChildren(const QModelIndex &parent) const
 }
 
 template<class T>
+bool DosQAbstractGenericModel<T>::hasIndex(int row, int column, const QModelIndex &parent) const
+{
+    bool result = false;
+    m_callbacks.hasIndex(m_modelObject, row, column, &parent, &result);
+    return result;
+}
+
+template<class T>
 bool DosQAbstractGenericModel<T>::canFetchMore(const QModelIndex &parent) const
 {
     bool result = false;
@@ -311,6 +319,11 @@ DosQAbstractItemModel::DosQAbstractItemModel(void *modelObject,
 bool DosQAbstractItemModel::defaultHasChildren(const QModelIndex &parent) const
 {
     return QAbstractItemModel::hasChildren(parent);
+}
+
+bool DosQAbstractItemModel::defaultHasIndex(int row, int column, const QModelIndex &parent) const
+{
+    return QAbstractItemModel::hasIndex(row, column, parent);
 }
 
 } // namespace DOS


### PR DESCRIPTION
I'm not sure all is correct. Particularly `QAbstractTableModel::defaultHasIndex` and `QAbstractListModel::defaultHasIndex`. And why doesn't `DosQAbstractGenericModel::hasIndex` override?