### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The following features are implementable from a binding language
 Currently we provide the prebuilt binaries for windows through the
 github [releases](https://github.com/filcuc/DOtherSide/releases) page
 
-###Linux
+### Linux
 Currently we provide the prebuilt binaries for the following
 Linux distributions through the [OpenSUSE OBS service](https://build.opensuse.org/package/show/home:filcuc/DOtherSide)
 * ```Archlinux``` : [here](http://software.opensuse.org/download.html?project=home%3Afilcuc&package=DOtherSide)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
