### PR TITLE
Fix MSVC Meson build

### DIFF
--- a/lib/meson.build
+++ b/lib/meson.build
@@ -11,7 +11,7 @@ lib_sources = [
   'src/OnSlotExecutedHandler.cpp',
 ]
 lib_include_directories = ['include', 'include/Qt']
-lib_pch = '../pch/lib_pch.h'
+lib_pch = ['../pch/lib_pch.h', '../pch/lib_pch.cpp']
 
 lib = shared_library('DOtherSide',
   sources : lib_sources,

--- a/pch/lib_pch.cpp
+++ b/pch/lib_pch.cpp
@@ -1,0 +1,1 @@
+#include "lib_pch.h"

--- a/pch/test_pch.cpp
+++ b/pch/test_pch.cpp
@@ -1,0 +1,1 @@
+#include "test_pch.h"

--- a/test/meson.build
+++ b/test/meson.build
@@ -2,7 +2,7 @@ test_dependencies = dependency('qt5', modules : ['Core', 'Gui', 'Widgets', 'Quic
 test_sources = ['test_dotherside.cpp', 'MockQAbstractItemModel.cpp', 'MockQObject.cpp']
 test_resources = 'Resources.qrc'
 test_include_directories = ['../lib/include', '../lib/include/Qt']
-test_pch = '../pch/test_pch.h'
+test_pch = ['../pch/test_pch.h', '../pch/test_pch.cpp']
 
 qt5 = import('qt5')
 test_moc_files = qt5.preprocess(moc_sources : test_sources, qresources : test_resources)


### PR DESCRIPTION
This change fixes building on windows with meson and ninja.

MSVC requires precompiled header to have corresponding .cpp file. 
(it is ignored for gcc by meson as specified here: https://github.com/mesonbuild/meson/blob/master/docs/markdown/Precompiled-headers.md)

It also adds missing Qt module (Gui), otherwise QtGui header cannot be found.
