### PR TITLE
Initial (QPixmap only) implementation of QQuickImageProvider

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -40,6 +40,7 @@ set(SRC_LIST
   src/DOtherSideTypesCpp.cpp
   src/DosQObjectImpl.cpp
   src/DosQAbstractItemModel.cpp
+  src/DosQQuickImageProvider.cpp
   )
 
 include_directories(include include/Qt)

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -114,7 +114,7 @@ DOS_API DosQQmlContext *DOS_CALL dos_qqmlapplicationengine_context(DosQQmlApplic
 /// \brief Calls the QQMLApplicationengine::addImageProvider    
 /// \param vptr The QQmlApplicationEngine
 /// \param vptr_i A QQuickImageProvider, the QQmlApplicationEngine takes ownership of this pointer
-DOS_API void DOS_CALL dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i);
+DOS_API void DOS_CALL dos_qqmlapplicationengine_addImageProvider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i);
 
 /// \brief Free the memory allocated for the given QQmlApplicationEngine
 /// \param vptr The QQmlApplicationEngine
@@ -133,7 +133,7 @@ DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create();
 /// \breif Frees a QQuickImageProvider
 DOS_API void DOS_CALL dos_qquickimageprovider_delete(DosQQuickImageProvider *vptr);
 /// \brief Register a callback which provides a new pixmap
-DOS_API void DOS_CALL dos_qquickimageprovider_registerpixmapcallback(DosQQuickImageProvider *vptr, pixmap_cb callback);
+DOS_API void DOS_CALL dos_qquickimageprovider_registerPixmapCallback(DosQQuickImageProvider *vptr, PixmapCallback callback);
 /// @}
 
 /// \defgroup QPixmap QPixmap
@@ -147,7 +147,7 @@ DOS_API void DOS_CALL dos_qpixmap_delete(DosPixmap *vptr);
 /// \brief Load image data into a QPixmap from an image file
 DOS_API void DOS_CALL dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format);
 /// \brief Load image data into a QPixmap from a buffer
-DOS_API void DOS_CALL dos_qpixmap_loadfromdata(DosPixmap *vptr, const unsigned char* data, unsigned int len);
+DOS_API void DOS_CALL dos_qpixmap_loadFromData(DosPixmap *vptr, const unsigned char* data, unsigned int len);
 /// \brief Fill a QPixmap with a single color
 DOS_API void DOS_CALL dos_qpixmap_fill(DosPixmap *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
 /// @}

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -111,9 +111,31 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_add_import_path(DosQQmlApplicati
 /// the engine and so it should die with the engine.
 DOS_API DosQQmlContext *DOS_CALL dos_qqmlapplicationengine_context(DosQQmlApplicationEngine *vptr);
 
+/// \breif Calls the QQMLApplicationengine::addImageProvider
+/// \param vptr The QQmlApplicationEngine
+/// \param vptr_i A QQuickImageProvider, the QQmlApplicationEngine takes ownership of this pointer
+DOS_API void DOS_CALL dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, DosQQuickImageProvider *vptr_i);
+
 /// \brief Free the memory allocated for the given QQmlApplicationEngine
 /// \param vptr The QQmlApplicationEngine
 DOS_API void DOS_CALL dos_qqmlapplicationengine_delete(DosQQmlApplicationEngine *vptr);
+
+/// @}
+
+/// \defgroup QQmlApplicationEngine QQmlApplicationEngine
+/// \brief Functions related to the QQmlApplicationEngine class
+/// @{
+
+/// \brief Create a new QQuickImageProvider
+/// \return A new QQuickImageProvider
+/// \note The returned QQuickImageProvider should be freed by using dos_qquickimageprovider_delete(DosQQuickImageProvider*) unless the QQuickImageProvider has been bound to a QQmlApplicationEngine
+DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create();
+/// \breif Frees a QQuickImageProvider
+DOS_API void DOS_CALL dos_qquickimageprovider_delete(DosQQuickImageProvider *vptr);
+DOS_API void DOS_CALL dos_qquickimageprovider_registerpixmapcallback(DosQQuickImageProvider *vptr, pixmap_cb callback);
+DOS_API DosPixmap *DOS_CALL dos_qpixmap_create(int width, int height);
+DOS_API void DOS_CALL dos_qpixmap_delete(DosPixmap *vptr);
+DOS_API void DOS_CALL dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format);
 
 /// @}
 
@@ -130,6 +152,7 @@ DOS_API void DOS_CALL dos_qquickstyle_set_fallback_style(const char *style);
 /// @}
 
 
+  
 /// \defgroup QQuickView QQuickView
 /// \brief Functions related to the QQuickView class
 /// @{

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -111,7 +111,7 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_add_import_path(DosQQmlApplicati
 /// the engine and so it should die with the engine.
 DOS_API DosQQmlContext *DOS_CALL dos_qqmlapplicationengine_context(DosQQmlApplicationEngine *vptr);
 
-/// \breif Calls the QQMLApplicationengine::addImageProvider
+/// \brief Calls the QQMLApplicationengine::addImageProvider    
 /// \param vptr The QQmlApplicationEngine
 /// \param vptr_i A QQuickImageProvider, the QQmlApplicationEngine takes ownership of this pointer
 DOS_API void DOS_CALL dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i);
@@ -122,8 +122,8 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_delete(DosQQmlApplicationEngine 
 
 /// @}
 
-/// \defgroup QQmlApplicationEngine QQmlApplicationEngine
-/// \brief Functions related to the QQmlApplicationEngine class
+/// \defgroup QQuickImageProvider QQuickImageProvider
+/// \brief Functions related to the QQuickImageProvider class
 /// @{
 
 /// \brief Create a new QQuickImageProvider
@@ -132,13 +132,26 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_delete(DosQQmlApplicationEngine 
 DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create();
 /// \breif Frees a QQuickImageProvider
 DOS_API void DOS_CALL dos_qquickimageprovider_delete(DosQQuickImageProvider *vptr);
+/// \brief Register a callback which provides a new pixmap
 DOS_API void DOS_CALL dos_qquickimageprovider_registerpixmapcallback(DosQQuickImageProvider *vptr, pixmap_cb callback);
+/// @}
+
+/// \defgroup QPixmap QPixmap
+/// \brief Functions related to the QPixmap class
+/// @{
+
+/// \brief Create a new QPixmap
 DOS_API DosPixmap *DOS_CALL dos_qpixmap_create(int width, int height);
+/// \brief Frees a QPixmap
 DOS_API void DOS_CALL dos_qpixmap_delete(DosPixmap *vptr);
+/// \brief Load image data into a QPixmap from an image file
 DOS_API void DOS_CALL dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format);
+/// \brief Load image data into a QPixmap from a buffer
 DOS_API void DOS_CALL dos_qpixmap_loadfromdata(DosPixmap *vptr, const unsigned char* data, unsigned int len);
+/// \brief Fill a QPixmap with a single color
 DOS_API void DOS_CALL dos_qpixmap_fill(DosPixmap *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
 /// @}
+
 
 /// \defgroup QQuickStyle QQuickStyle
 /// \brief Functions related to the QQuickStyle class

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -114,7 +114,7 @@ DOS_API DosQQmlContext *DOS_CALL dos_qqmlapplicationengine_context(DosQQmlApplic
 /// \breif Calls the QQMLApplicationengine::addImageProvider
 /// \param vptr The QQmlApplicationEngine
 /// \param vptr_i A QQuickImageProvider, the QQmlApplicationEngine takes ownership of this pointer
-DOS_API void DOS_CALL dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, DosQQuickImageProvider *vptr_i);
+DOS_API void DOS_CALL dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i);
 
 /// \brief Free the memory allocated for the given QQmlApplicationEngine
 /// \param vptr The QQmlApplicationEngine
@@ -136,7 +136,6 @@ DOS_API void DOS_CALL dos_qquickimageprovider_registerpixmapcallback(DosQQuickIm
 DOS_API DosPixmap *DOS_CALL dos_qpixmap_create(int width, int height);
 DOS_API void DOS_CALL dos_qpixmap_delete(DosPixmap *vptr);
 DOS_API void DOS_CALL dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format);
-
 /// @}
 
 /// \defgroup QQuickStyle QQuickStyle

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -136,6 +136,8 @@ DOS_API void DOS_CALL dos_qquickimageprovider_registerpixmapcallback(DosQQuickIm
 DOS_API DosPixmap *DOS_CALL dos_qpixmap_create(int width, int height);
 DOS_API void DOS_CALL dos_qpixmap_delete(DosPixmap *vptr);
 DOS_API void DOS_CALL dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format);
+DOS_API void DOS_CALL dos_qpixmap_loadfromdata(DosPixmap *vptr, const unsigned char* data, unsigned int len);
+DOS_API void DOS_CALL dos_qpixmap_fill(DosPixmap *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
 /// @}
 
 /// \defgroup QQuickStyle QQuickStyle

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -129,11 +129,9 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_delete(DosQQmlApplicationEngine 
 /// \brief Create a new QQuickImageProvider
 /// \return A new QQuickImageProvider
 /// \note The returned QQuickImageProvider should be freed by using dos_qquickimageprovider_delete(DosQQuickImageProvider*) unless the QQuickImageProvider has been bound to a QQmlApplicationEngine
-DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create();
+DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create(PixmapCallback callback);
 /// \breif Frees a QQuickImageProvider
 DOS_API void DOS_CALL dos_qquickimageprovider_delete(DosQQuickImageProvider *vptr);
-/// \brief Register a callback which provides a new pixmap
-DOS_API void DOS_CALL dos_qquickimageprovider_registerPixmapCallback(DosQQuickImageProvider *vptr, PixmapCallback callback);
 /// @}
 
 /// \defgroup QPixmap QPixmap

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -73,7 +73,7 @@ typedef void DosPixmap;
 /// \param height pointer to the height of the image
 /// \param requestedHeight sourceSize.height attribute
 /// \param requestedWidth sourcesSize.width attribute
-/// \note id is the substring provided after the name in an image source URL for example "image://<provider_id>/<id>
+/// \note \p id is the trailing part of an image source url for example "image://<provider_id>/<id>
 typedef DosPixmap* (*PixmapCallback)(const char *id, int *width, int *height, int requestedWidth, int requestedHeight);
 
 

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -61,6 +61,21 @@ typedef void DosQMetaObject;
 /// A pointer to a QObject
 typedef void DosQObject;
 
+/// A pointer to a QQuickImageProvider
+typedef void DosQQuickImageProvider;
+
+typedef void DosPixmap;
+
+struct pixmap_request {
+    const char *id;
+    int *width;
+    int *height;
+    int requestedWidth;
+    int requestedHeight;
+};
+
+typedef DosPixmap* (*pixmap_cb)(pixmap_request request);
+
 /// Called when a property is readed/written or a slot should be executed
 /// \param self The pointer of QObject in the binded language
 /// \param slotName The slotName as DosQVariant

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -67,15 +67,15 @@ typedef void DosQQuickImageProvider;
 /// A pointer to a QPixmap
 typedef void DosPixmap;
 
-struct pixmap_request {
-    const char *id;
-    int *width;
-    int *height;
-    int requestedWidth;
-    int requestedHeight;
-};
+/// A pixmap callback to be supplied to an image provider
+/// \param id Image source id
+/// \param width pointer to the width of the image
+/// \param height pointer to the height of the image
+/// \param requestedHeight sourceSize.height attribute
+/// \param requestedWidth sourcesSize.width attribute
+/// \note id is the substring provided after the name in an image source URL for example "image://<provider_id>/<id>
+typedef DosPixmap* (*PixmapCallback)(const char *id, int *width, int *height, int requestedWidth, int requestedHeight);
 
-typedef DosPixmap* (*PixmapCallback)(pixmap_request request);
 
 /// Called when a property is readed/written or a slot should be executed
 /// \param self The pointer of QObject in the binded language

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -64,6 +64,7 @@ typedef void DosQObject;
 /// A pointer to a QQuickImageProvider
 typedef void DosQQuickImageProvider;
 
+/// A pointer to a QPixmap
 typedef void DosPixmap;
 
 struct pixmap_request {
@@ -74,7 +75,7 @@ struct pixmap_request {
     int requestedHeight;
 };
 
-typedef DosPixmap* (*pixmap_cb)(pixmap_request request);
+typedef DosPixmap* (*PixmapCallback)(pixmap_request request);
 
 /// Called when a property is readed/written or a slot should be executed
 /// \param self The pointer of QObject in the binded language

--- a/lib/include/DOtherSide/DOtherSideTypesCpp.h
+++ b/lib/include/DOtherSide/DOtherSideTypesCpp.h
@@ -152,5 +152,4 @@ struct QmlRegisterType {
     DeleteDObject deleteDObject;
 };
 
-
 } // namespace DOS

--- a/lib/include/DOtherSide/DosQQuickImageProvider.h
+++ b/lib/include/DOtherSide/DosQQuickImageProvider.h
@@ -1,0 +1,21 @@
+#pragma once
+
+// std
+#include <iostream>
+
+// Qt
+#include <QPixmap>
+#include <QQuickImageProvider>
+
+#include "DOtherSideTypes.h"
+
+class DosImageProvider : public QQuickImageProvider
+{
+public:
+    DosImageProvider();
+    QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
+    void setPixmapCallback(pixmap_cb fn);
+
+private:
+    pixmap_cb _pixmap_callback;
+};

--- a/lib/include/DOtherSide/DosQQuickImageProvider.h
+++ b/lib/include/DOtherSide/DosQQuickImageProvider.h
@@ -12,9 +12,8 @@
 class DosImageProvider : public QQuickImageProvider
 {
 public:
-    DosImageProvider();
+    DosImageProvider(PixmapCallback);
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
-    void setPixmapCallback(PixmapCallback fn);
 
 private:
     PixmapCallback m_pixmap_callback;

--- a/lib/include/DOtherSide/DosQQuickImageProvider.h
+++ b/lib/include/DOtherSide/DosQQuickImageProvider.h
@@ -12,7 +12,7 @@
 class DosImageProvider : public QQuickImageProvider
 {
 public:
-    DosImageProvider(PixmapCallback);
+    DosImageProvider(PixmapCallback callback);
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
 
 private:

--- a/lib/include/DOtherSide/DosQQuickImageProvider.h
+++ b/lib/include/DOtherSide/DosQQuickImageProvider.h
@@ -14,8 +14,8 @@ class DosImageProvider : public QQuickImageProvider
 public:
     DosImageProvider();
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize);
-    void setPixmapCallback(pixmap_cb fn);
+    void setPixmapCallback(PixmapCallback fn);
 
 private:
-    pixmap_cb _pixmap_callback;
+    PixmapCallback m_pixmap_callback;
 };

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -137,11 +137,11 @@ void dos_qqmlapplicationengine_add_import_path(::DosQQmlApplicationEngine *vptr,
     return engine->rootContext();
 }
 
-void dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, DosQQuickImageProvider *vptr_i)
+void dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i)
 {
   auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-  auto provider = static_cast<QQuickImageProvider *>(vptr_i);
-  engine->addImageProvider(QString("test"), provider);
+  auto provider = static_cast<DosImageProvider *>(vptr_i);
+  engine->addImageProvider(QString(name), provider);
 }
 
 void dos_qqmlapplicationengine_delete(::DosQQmlApplicationEngine *vptr)
@@ -158,7 +158,7 @@ void dos_qqmlapplicationengine_delete(::DosQQmlApplicationEngine *vptr)
 
 void dos_qquickimageprovider_delete(::DosQQuickImageProvider *vptr)
 {
-    auto provider = static_cast<QQuickImageProvider *>(vptr);
+    auto provider = static_cast<DosImageProvider *>(vptr);
     delete provider;
 }
 

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -11,6 +11,7 @@
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQuick/QQuickView>
+#include <QQuickImageProvider>
 #ifdef QT_QUICKCONTROLS2_LIB
 #include <QtQuickControls2/QQuickStyle>
 #endif
@@ -23,6 +24,7 @@
 #include "DOtherSide/DosQObjectImpl.h"
 #include "DOtherSide/DosQAbstractItemModel.h"
 #include "DOtherSide/DosQDeclarative.h"
+#include "DOtherSide/DosQQuickImageProvider.h"
 
 namespace {
 void register_meta_types()
@@ -135,10 +137,51 @@ void dos_qqmlapplicationengine_add_import_path(::DosQQmlApplicationEngine *vptr,
     return engine->rootContext();
 }
 
+void dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, DosQQuickImageProvider *vptr_i)
+{
+  auto engine = static_cast<QQmlApplicationEngine *>(vptr);
+  auto provider = static_cast<QQuickImageProvider *>(vptr_i);
+  engine->addImageProvider(QString("test"), provider);
+}
+
 void dos_qqmlapplicationengine_delete(::DosQQmlApplicationEngine *vptr)
 {
     auto engine = static_cast<QQmlApplicationEngine *>(vptr);
     delete engine;
+}
+
+
+::DosQQuickImageProvider *dos_qquickimageprovider_create()
+{
+    return new DosImageProvider();
+}
+
+void dos_qquickimageprovider_delete(::DosQQuickImageProvider *vptr)
+{
+    auto provider = static_cast<QQuickImageProvider *>(vptr);
+    delete provider;
+}
+
+void dos_qquickimageprovider_registerpixmapcallback(::DosQQuickImageProvider *vptr, pixmap_cb callback) {
+    auto provider = static_cast<DosImageProvider *>(vptr);
+    provider->setPixmapCallback(callback);
+}
+
+::DosPixmap *dos_qpixmap_create(int width, int height)
+{
+    return new QPixmap(width, height);
+}
+
+void dos_qpixmap_delete(DosPixmap *vptr)
+{
+    auto pixmap = static_cast<QPixmap *>(vptr);
+    delete pixmap;
+}
+
+void dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format)
+{
+    auto pixmap = static_cast<QPixmap *>(vptr);
+    pixmap->load(QString(filepath), format);
 }
 
 ::DosQQuickView *dos_qquickview_create()

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -137,7 +137,7 @@ void dos_qqmlapplicationengine_add_import_path(::DosQQmlApplicationEngine *vptr,
     return engine->rootContext();
 }
 
-void dos_qqmlapplicationengine_addimageprovider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i)
+void dos_qqmlapplicationengine_addImageProvider(DosQQmlApplicationEngine *vptr, const char* name, DosQQuickImageProvider *vptr_i)
 {
   auto engine = static_cast<QQmlApplicationEngine *>(vptr);
   auto provider = static_cast<DosImageProvider *>(vptr_i);
@@ -162,7 +162,7 @@ void dos_qquickimageprovider_delete(::DosQQuickImageProvider *vptr)
     delete provider;
 }
 
-void dos_qquickimageprovider_registerpixmapcallback(::DosQQuickImageProvider *vptr, pixmap_cb callback) {
+void dos_qquickimageprovider_registerPixmapCallback(::DosQQuickImageProvider *vptr, PixmapCallback callback) {
     auto provider = static_cast<DosImageProvider *>(vptr);
     provider->setPixmapCallback(callback);
 }
@@ -184,7 +184,7 @@ void dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format)
     pixmap->load(QString(filepath), format);
 }
 
-void dos_qpixmap_loadfromdata(DosPixmap *vptr, const unsigned char* data, unsigned int len)
+void dos_qpixmap_loadFromData(DosPixmap *vptr, const unsigned char* data, unsigned int len)
 {
     auto pixmap = static_cast<QPixmap *>(vptr);
     pixmap->loadFromData(data, len);

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -151,20 +151,15 @@ void dos_qqmlapplicationengine_delete(::DosQQmlApplicationEngine *vptr)
 }
 
 
-::DosQQuickImageProvider *dos_qquickimageprovider_create()
+::DosQQuickImageProvider *dos_qquickimageprovider_create(PixmapCallback callback)
 {
-    return new DosImageProvider();
+    return new DosImageProvider(callback);
 }
 
 void dos_qquickimageprovider_delete(::DosQQuickImageProvider *vptr)
 {
     auto provider = static_cast<DosImageProvider *>(vptr);
     delete provider;
-}
-
-void dos_qquickimageprovider_registerPixmapCallback(::DosQQuickImageProvider *vptr, PixmapCallback callback) {
-    auto provider = static_cast<DosImageProvider *>(vptr);
-    provider->setPixmapCallback(callback);
 }
 
 ::DosPixmap *dos_qpixmap_create(int width, int height)

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -184,6 +184,18 @@ void dos_qpixmap_load(DosPixmap *vptr, const char* filepath, const char* format)
     pixmap->load(QString(filepath), format);
 }
 
+void dos_qpixmap_loadfromdata(DosPixmap *vptr, const unsigned char* data, unsigned int len)
+{
+    auto pixmap = static_cast<QPixmap *>(vptr);
+    pixmap->loadFromData(data, len);
+}
+
+void dos_qpixmap_fill(DosPixmap *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a)
+{
+    auto pixmap = static_cast<QPixmap *>(vptr);
+    pixmap->fill(QColor(r, g, b, a));
+}
+
 ::DosQQuickView *dos_qquickview_create()
 {
     return new QQuickView();

--- a/lib/src/DosQQuickImageProvider.cpp
+++ b/lib/src/DosQQuickImageProvider.cpp
@@ -1,0 +1,19 @@
+#include "DOtherSide/DosQQuickImageProvider.h"
+
+DosImageProvider::DosImageProvider() : QQuickImageProvider(QQuickImageProvider::Pixmap)
+{
+}
+
+QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
+{
+    pixmap_request request {
+        id.toLatin1().data(), &size->rwidth(), &size->rheight(), size->width(), size->height() };                
+    auto pixmap = _pixmap_callback(request);
+    auto pixmap_copy = *(static_cast<QPixmap*>(pixmap));
+    delete (static_cast<QPixmap*>(pixmap));
+    return pixmap_copy;
+}
+
+void DosImageProvider::setPixmapCallback(pixmap_cb fn) {
+    _pixmap_callback = fn;
+}

--- a/lib/src/DosQQuickImageProvider.cpp
+++ b/lib/src/DosQQuickImageProvider.cpp
@@ -8,12 +8,12 @@ QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QS
 {
     pixmap_request request {
         id.toLatin1().data(), &size->rwidth(), &size->rheight(), size->width(), size->height() };                
-    auto pixmap = _pixmap_callback(request);
+    auto pixmap = m_pixmap_callback(request);
     auto pixmap_copy = *(static_cast<QPixmap*>(pixmap));
     delete (static_cast<QPixmap*>(pixmap));
     return pixmap_copy;
 }
 
-void DosImageProvider::setPixmapCallback(pixmap_cb fn) {
-    _pixmap_callback = fn;
+void DosImageProvider::setPixmapCallback(PixmapCallback fn) {
+    m_pixmap_callback = fn;
 }

--- a/lib/src/DosQQuickImageProvider.cpp
+++ b/lib/src/DosQQuickImageProvider.cpp
@@ -6,14 +6,12 @@ DosImageProvider::DosImageProvider() : QQuickImageProvider(QQuickImageProvider::
 
 QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
 {
-    pixmap_request request {
-        id.toLatin1().data(), &size->rwidth(), &size->rheight(), size->width(), size->height() };                
-    auto pixmap = m_pixmap_callback(request);
+    auto pixmap = m_pixmap_callback(id.toLatin1().data(), &size->rwidth(), &size->rheight(), size->width(), size->height());
     auto pixmap_copy = *(static_cast<QPixmap*>(pixmap));
     delete (static_cast<QPixmap*>(pixmap));
     return pixmap_copy;
 }
 
-void DosImageProvider::setPixmapCallback(PixmapCallback fn) {
-    m_pixmap_callback = fn;
+void DosImageProvider::setPixmapCallback(PixmapCallback callback) {
+    m_pixmap_callback = callback;
 }

--- a/lib/src/DosQQuickImageProvider.cpp
+++ b/lib/src/DosQQuickImageProvider.cpp
@@ -1,6 +1,7 @@
 #include "DOtherSide/DosQQuickImageProvider.h"
 
-DosImageProvider::DosImageProvider() : QQuickImageProvider(QQuickImageProvider::Pixmap)
+DosImageProvider::DosImageProvider(PixmapCallback callback) : QQuickImageProvider(QQuickImageProvider::Pixmap),
+                                                              m_pixmap_callback(callback)
 {
 }
 
@@ -10,8 +11,4 @@ QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QS
     auto pixmap_copy = *(static_cast<QPixmap*>(pixmap));
     delete (static_cast<QPixmap*>(pixmap));
     return pixmap_copy;
-}
-
-void DosImageProvider::setPixmapCallback(PixmapCallback callback) {
-    m_pixmap_callback = callback;
 }


### PR DESCRIPTION
This isn't really complete, I just wanted to check with you this is structured as you want it.

I've also added a test implementation in dqml which can load a png image and display it. I'd like to implement all of the QPixmap API, as well as QImage. However I'm not sure how much of the Qt API you want to bring in as this would probably pull in QPainter etc. it may be worth just sticking to QPixmap.