### PR TITLE
Fix relative include

### DIFF
--- a/lib/include/DOtherSide/DOtherSideTypesCpp.h
+++ b/lib/include/DOtherSide/DOtherSideTypesCpp.h
@@ -3,7 +3,7 @@
 // std
 #include <memory>
 // Qt
-#include <QtGlobal>
+#include <QtCore/QtGlobal>
 #include <QtCore/QString>
 #include <QtCore/QMetaType>
 // DOtherSide

--- a/lib/include/DOtherSide/DosQAbstractItemModel.h
+++ b/lib/include/DOtherSide/DosQAbstractItemModel.h
@@ -1,9 +1,9 @@
 #pragma once
 
 // Qt
-#include <QAbstractItemModel>
-#include <QAbstractListModel>
-#include <QAbstractTableModel>
+#include <QtCore/QAbstractItemModel>
+#include <QtCore/QAbstractListModel>
+#include <QtCore/QAbstractTableModel>
 
 // DOtherSide
 #include "DOtherSide/DOtherSideTypes.h"

--- a/lib/include/DOtherSide/DosQObject.h
+++ b/lib/include/DOtherSide/DosQObject.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // Qt
-#include <QObject>
+#include <QtCore/QObject>
 #include <functional>
 // DOtherSide
 #include "DOtherSideTypesCpp.h"

--- a/lib/include/DOtherSide/DosQObjectImpl.h
+++ b/lib/include/DOtherSide/DosQObjectImpl.h
@@ -3,7 +3,7 @@
 // std
 #include <vector>
 // Qt
-#include <QMutex>
+#include <QtCore/QMutex>
 #include <QtCore/QString>
 #include <QtCore/QVariant>
 // DOtherSide

--- a/lib/include/DOtherSide/DosQQuickImageProvider.h
+++ b/lib/include/DOtherSide/DosQQuickImageProvider.h
@@ -4,8 +4,8 @@
 #include <iostream>
 
 // Qt
-#include <QPixmap>
-#include <QQuickImageProvider>
+#include <QtGui/QPixmap>
+#include <QtQuick/QQuickImageProvider>
 
 #include "DOtherSideTypes.h"
 

--- a/lib/include/DOtherSide/OnSlotExecutedHandler.h
+++ b/lib/include/DOtherSide/OnSlotExecutedHandler.h
@@ -3,7 +3,7 @@
 // std
 #include <vector>
 // Qt
-#include <QVariant>
+#include <QtCore/QVariant>
 // DOtherSide
 #include "DOtherSide/DOtherSideTypesCpp.h"
 

--- a/lib/include/DOtherSide/Utils.h
+++ b/lib/include/DOtherSide/Utils.h
@@ -5,7 +5,7 @@
 #include <functional>
 #include <type_traits>
 // Qt
-#include <QtGlobal>
+#include <QtCore/QtGlobal>
 
 namespace DOS {
 

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -11,7 +11,7 @@
 #include <QtQml/QQmlContext>
 #include <QtQml/QQmlApplicationEngine>
 #include <QtQuick/QQuickView>
-#include <QQuickImageProvider>
+#include <QtQuick/QQuickImageProvider>
 #ifdef QT_QUICKCONTROLS2_LIB
 #include <QtQuickControls2/QQuickStyle>
 #endif


### PR DESCRIPTION
Fixes includes that are relative to include path to absolute path as it is with most qt includes to be consistent. This also allows users of this library to put only DOtherSide/include and DOtherSide/include/Qt to include path which is nice.