### PR TITLE
Added wrapper for QObject->property() and QObject->setProperty()

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -686,6 +686,22 @@ DOS_API void DOS_CALL dos_qobject_setObjectName(DosQObject *vptr, const char *na
 /// \param vptr The QObject
 DOS_API void DOS_CALL dos_qobject_delete(DosQObject *vptr);
 
+/// \brief Read Value of a property by its name
+/// \param vptr The QObject
+/// \param propertyName the Name of the property to be read
+/// \returns Value of the given property
+/// \note returns an empty QVariant if the propertyName does not exist
+DOS_API DosQVariant *DOS_CALL dos_qobject_readProperty(DosQObject *vptr,
+                                                       const char *propertyName);
+
+/// \brief Write Value to a property by its name
+/// \param vptr The QObject
+/// \param propertyName The Name of the property to be written
+/// \param value The value to be written
+/// \return Result as bool
+DOS_API bool DOS_CALL dos_qobject_writeProperty(DosQObject  *vptr,
+                                                const char  *propertyName,
+                                                DosQVariant *value);
 /// @}
 
 

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -533,6 +533,19 @@ void dos_qobject_setObjectName(::DosQObject *vptr, const char *name)
     object->setObjectName(QString::fromUtf8(name));
 }
 
+::DosQVariant *dos_qobject_readProperty(DosQObject *vptr, const char *propertyName) {
+    auto object = static_cast<const QObject *>(vptr);
+    auto result = new QVariant(object->property(propertyName));
+    return static_cast<QVariant *>(result);
+
+}
+
+bool dos_qobject_writeProperty(::DosQObject *vptr, const char *propertyName, ::DosQVariant *dosValue){
+    auto object = static_cast<QObject *>(vptr);
+    auto value = static_cast<QVariant *>(dosValue);
+    return object->setProperty(propertyName, *value);
+}
+
 ::DosQModelIndex *dos_qmodelindex_create()
 {
     return new QModelIndex();

--- a/test/test_dotherside.cpp
+++ b/test/test_dotherside.cpp
@@ -184,6 +184,15 @@ private slots:
         QVERIFY(value == nullptr);
     }
 
+    void testQVariant(){
+        QVariant original("foo");
+        QVERIFY(original.type() == QVariant::String);
+        auto copypointer = dos_qvariant_create_qvariant(&original);
+        QVariant copy = *static_cast<QVariant *>(copypointer);
+        QVERIFY(copy.type() == QVariant::String);
+        QCOMPARE(copy.toString().toStdString(),original.toString().toStdString());
+    }
+
     void testArray()
     {
         std::vector<DosQVariant *> data ({
@@ -399,6 +408,20 @@ private slots:
         QVERIFY(QMetaObject::invokeMethod(testCase, "testPropertyReadAndWrite", Q_RETURN_ARG(QVariant, result)));
         QVERIFY(result.type() == QVariant::Bool);
         QVERIFY(result.toBool());
+    }
+
+    void testPropertyGetSet(){
+        auto testobject = new MockQObject;
+        QObject *data = static_cast<QObject *>(testobject->data());
+        data->setProperty("name", "foo");
+        auto value = *static_cast<QVariant *>(dos_qobject_readProperty(data, "name"));
+        QVERIFY(value.type() == QVariant::String);
+        QVERIFY(value.toString() == "foo");
+        QVariant bar("bar");
+        dos_qobject_writeProperty(data, "name", &bar);
+        value = *static_cast<QVariant *>(dos_qobject_readProperty(data, "name"));
+        QVERIFY(value.type() == QVariant::String);
+        QVERIFY(value.toString() == "bar");
     }
 
     void testSignalEmittion()


### PR DESCRIPTION
I added an easy way to get/set properties of any QObject with just their name and value, 
including tests for the new Wrapper and for `dos_qvariant_create_qvariant`