### PR TITLE
long long support

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -292,6 +292,18 @@ DOS_API DosQVariant *DOS_CALL dos_qvariant_create(void);
 /// \note The returned QVariant should be freed using dos_qvariant_delete()
 DOS_API DosQVariant *DOS_CALL dos_qvariant_create_int(int value);
 
+/// \brief Create a new QVariant holding a long long value
+/// \return The a new QVariant
+/// \param value The value
+/// \note The returned QVariant should be freed using dos_qvariant_delete()
+DOS_API DosQVariant *DOS_CALL dos_qvariant_create_longlong(long long value);
+
+/// \brief Create a new QVariant holding an usigned long long value
+/// \return The a new QVariant
+/// \param value The value
+/// \note The returned QVariant should be freed using dos_qvariant_delete()
+DOS_API DosQVariant *DOS_CALL dos_qvariant_create_ulonglong(unsigned long long value);
+
 /// \brief Create a new QVariant holding a bool value
 /// \return The a new QVariant
 /// \param value The bool value
@@ -340,6 +352,16 @@ DOS_API DosQVariant *DOS_CALL dos_qvariant_create_array(int size, DosQVariant **
 /// \param vptr The QVariant
 /// \param value The int value
 DOS_API void DOS_CALL dos_qvariant_setInt(DosQVariant *vptr, int value);
+
+/// \brief Calls the QVariant::setValue<long long>() function
+/// \param vptr The QVariant
+/// \param value The long long value
+DOS_API void DOS_CALL dos_qvariant_setLongLong(DosQVariant *vptr, long long value);
+
+/// \brief Calls the QVariant::setValue<unsigned long long>() function
+/// \param vptr The QVariant
+/// \param value The unsigned long long value
+DOS_API void DOS_CALL dos_qvariant_setULongLong(DosQVariant *vptr, unsigned long long value);
 
 /// \brief Calls the QVariant::setValue<bool>() function
 /// \param vptr The QVariant
@@ -392,6 +414,16 @@ DOS_API void DOS_CALL dos_qvariant_assign(DosQVariant *vptr, const DosQVariant *
 /// \param vptr The QVariant
 /// \return The int value
 DOS_API int DOS_CALL dos_qvariant_toInt(const DosQVariant *vptr);
+
+/// \brief Calls the QVariant::value<long long>() function
+/// \param vptr The QVariant
+/// \return The int value
+DOS_API long long DOS_CALL dos_qvariant_toLongLong(const DosQVariant *vptr);
+
+/// \brief Calls the QVariant::value<unsigned long long>() function
+/// \param vptr The QVariant
+/// \return The int value
+DOS_API unsigned long long DOS_CALL dos_qvariant_toULongLong(const DosQVariant *vptr);
 
 /// \brief Calls the QVariant::value<bool>() function
 /// \param vptr The QVariant

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -330,6 +330,16 @@ void dos_qqmlcontext_setcontextproperty(::DosQQmlContext *vptr, const char *name
     return new QVariant(value);
 }
 
+::DosQVariant *dos_qvariant_create_longlong(long long value)
+{
+    return new QVariant(value);
+}
+
+::DosQVariant *dos_qvariant_create_ulonglong(unsigned long long value)
+{
+    return new QVariant(value);
+}
+
 ::DosQVariant *dos_qvariant_create_bool(bool value)
 {
     return new QVariant(value);
@@ -400,6 +410,18 @@ int dos_qvariant_toInt(const ::DosQVariant *vptr)
     return variant->toInt();
 }
 
+long long dos_qvariant_toLongLong(const ::DosQVariant *vptr)
+{
+    auto variant = static_cast<const QVariant *>(vptr);
+    return variant->toLongLong();
+}
+
+unsigned long long dos_qvariant_toULongLong(const ::DosQVariant *vptr)
+{
+    auto variant = static_cast<const QVariant *>(vptr);
+    return variant->toULongLong();
+}
+
 bool dos_qvariant_toBool(const ::DosQVariant *vptr)
 {
     auto variant = static_cast<const QVariant *>(vptr);
@@ -443,6 +465,18 @@ DosQVariantArray *dos_qvariant_toArray(const DosQVariant *vptr)
 }
 
 void dos_qvariant_setInt(::DosQVariant *vptr, int value)
+{
+    auto variant = static_cast<QVariant *>(vptr);
+    *variant = value;
+}
+
+void dos_qvariant_setLongLong(::DosQVariant *vptr, long long value)
+{
+    auto variant = static_cast<QVariant *>(vptr);
+    *variant = value;
+}
+
+void dos_qvariant_setULongLong(::DosQVariant *vptr, unsigned long long value)
 {
     auto variant = static_cast<QVariant *>(vptr);
     *variant = value;


### PR DESCRIPTION
to correctly handle `int` vs `cint` in nim