### PR TITLE
Fixed broken model instantiated from Qml

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -32,6 +32,10 @@ macro(add_target name type)
         target_compile_definitions(${name} PRIVATE -DWIN32)
     endif()
 
+    if(NOT MSVC)
+      target_compile_options(${name} PRIVATE -Wall -Wextra -Wpedantic -Werror)
+    endif()
+
     set_target_properties(${name} PROPERTIES CXX_STANDARD 11 AUTOMOC ON)
 
     target_include_directories(${name} PUBLIC include include/Qt)

--- a/lib/include/DOtherSide/DosIQAbstractItemModelImpl.h
+++ b/lib/include/DOtherSide/DosIQAbstractItemModelImpl.h
@@ -37,18 +37,6 @@ public:
     /// Destructor
     virtual ~DosIQAbstractItemModelImpl() = default;
 
-    /// @see QAbstractItemModel::setData
-    virtual bool defaultSetData(const QModelIndex &index, const QVariant &value, int role = Qt::EditRole) = 0;
-
-    /// @see QAbstractItemModel::flags
-    virtual Qt::ItemFlags defaultFlags(const QModelIndex &index) const = 0;
-
-    /// @see QAbstractItemModel::headerData
-    virtual QVariant defaultHeaderData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const = 0;
-
-    /// @see QAbstractItemModel::roleNames
-    virtual QHash<int, QByteArray> defaultRoleNames() const = 0;
-
     /// @see QAbstractItemModel::beginInsertRows
     virtual void publicBeginInsertRows(const QModelIndex &index, int first, int last) = 0;
 
@@ -84,15 +72,6 @@ public:
 
     /// @see QAbstractItemModel::createIndex
     virtual QModelIndex publicCreateIndex(int row, int column, void *data = nullptr) const = 0;
-
-    /// @see QAbstractItemModel::hasChildren
-    virtual bool defaultHasChildren(const QModelIndex &parent) const = 0;
-
-    /// @see QAbstractItemModel::canFetchMore
-    virtual bool defaultCanFetchMore(const QModelIndex &parent) const = 0;
-
-    /// @see QAbstractItemModel::fetchMore
-    virtual void defaultFetchMore(const QModelIndex &parent) = 0;
 
     ///  @see QAbstractItemModel::hasIndex
     virtual bool hasIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const = 0;

--- a/lib/include/DOtherSide/DosQAbstractItemModel.h
+++ b/lib/include/DOtherSide/DosQAbstractItemModel.h
@@ -118,18 +118,6 @@ public:
     /// Expose createIndex
     QModelIndex publicCreateIndex(int row, int column, void *data = nullptr) const override;
 
-    /// Expose the not overriden flags
-    Qt::ItemFlags defaultFlags(const QModelIndex &index) const override;
-
-    /// Expose the not overriden header data
-    QVariant defaultHeaderData(int section, Qt::Orientation orientation, int role) const override;
-
-    /// Expose the not overriden roleNames
-    QHash<int, QByteArray> defaultRoleNames() const override;
-
-    /// Expose the not overriden setData
-    bool defaultSetData(const QModelIndex &index, const QVariant &value, int role) override;
-
     /// Expose the hasChildren
     bool hasChildren(const QModelIndex &parent = QModelIndex()) const override;
 
@@ -139,48 +127,16 @@ public:
     /// Expose the canFetchMore
     bool canFetchMore(const QModelIndex &parent) const override;
 
-    /// Expose the not override canFetchMore
-    bool defaultCanFetchMore(const QModelIndex &parent) const override;
-
     /// Expose the fetchMore
     void fetchMore(const QModelIndex &parent) override;
-
-    /// Expose the not overriden fetchMore
-    void defaultFetchMore(const QModelIndex &parent) override;
-
 private:
     std::unique_ptr<DosIQObjectImpl> m_impl;
     void *m_modelObject;
     DosQAbstractItemModelCallbacks m_callbacks;
 };
 
-class DosQAbstractItemModel : public DosQAbstractGenericModel<QAbstractItemModel>
-{
-public:
-    using DosQAbstractGenericModel::DosQAbstractGenericModel;
-
-    bool defaultHasChildren(const QModelIndex &parent) const override;
-};
-
-class DosQAbstractTableModel : public DosQAbstractGenericModel<QAbstractTableModel>
-{
-public:
-    using DosQAbstractGenericModel::DosQAbstractGenericModel;
-
-    QModelIndex defaultParent(const QModelIndex &child) const;
-    QModelIndex defaultIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;
-    bool defaultHasChildren(const QModelIndex &parent) const override;
-};
-
-class DosQAbstractListModel : public DosQAbstractGenericModel<QAbstractListModel>
-{
-public:
-    using DosQAbstractGenericModel::DosQAbstractGenericModel;
-
-    QModelIndex defaultParent(const QModelIndex &child) const;
-    QModelIndex defaultIndex(int row, int column, const QModelIndex &parent = QModelIndex()) const;
-    int defaultColumnCount(const QModelIndex &parent) const;
-    bool defaultHasChildren(const QModelIndex &parent) const override;
-};
+using DosQAbstractItemModel = DosQAbstractGenericModel<QAbstractItemModel>;
+using DosQAbstractTableModel  = DosQAbstractGenericModel<QAbstractTableModel>;
+using DosQAbstractListModel = DosQAbstractGenericModel<QAbstractListModel>;
 
 } // namespace DOS

--- a/lib/include/DOtherSide/DosQAbstractItemModelWrapper.h
+++ b/lib/include/DOtherSide/DosQAbstractItemModelWrapper.h
@@ -19,12 +19,14 @@
 
 #pragma once
 
+#include <QtQml/QQmlEngine>
+
 #include "DOtherSide/DosQAbstractItemModel.h"
 #include "DOtherSide/DosQMetaObject.h"
 
 namespace DOS {
-template <int, int>
-class DosQAbstractItemModelWrapper : public QAbstractItemModel, public DosIQObjectImpl
+template <typename T, int, int>
+class DosQAbstractItemModelWrapper : public T, public DosIQObjectImpl
 {
 public:
     static const QMetaObject staticMetaObject;
@@ -90,49 +92,47 @@ private:
     static QmlRegisterType m_data;
 };
 
-template<int N, int M>
-const QMetaObject DosQAbstractItemModelWrapper<N, M>::staticMetaObject = QAbstractItemModel::staticMetaObject;
+template<typename T, int N, int M>
+const QMetaObject DosQAbstractItemModelWrapper<T, N, M>::staticMetaObject = T::staticMetaObject;
 
-template<int N, int M>
-QmlRegisterType DosQAbstractItemModelWrapper<N, M>::m_data;
+template<typename T, int N, int M>
+QmlRegisterType DosQAbstractItemModelWrapper<T, N, M>::m_data;
 
-template<int N, int M>
-int DosQAbstractItemModelWrapper<N, M>::m_id = -1;
+template<typename T, int N, int M>
+int DosQAbstractItemModelWrapper<T, N, M>::m_id = -1;
 
-template<int N, int M>
-DosQAbstractItemModelWrapper<N, M>::DosQAbstractItemModelWrapper(QObject *parent)
-    : QAbstractItemModel(parent)
+template<typename T, int N, int M>
+DosQAbstractItemModelWrapper<T, N, M>::DosQAbstractItemModelWrapper(QObject *parent)
+    : T(parent)
     , m_dObject(nullptr)
     , m_impl(nullptr)
 {
     void *impl = nullptr;
     m_data.createDObject(m_id, static_cast<QObject *>(this), &m_dObject, &impl);
-    beginResetModel();
     m_impl = dynamic_cast<QAbstractItemModel *>(static_cast<QObject *>(impl));
-    QObject::connect(m_impl, &QAbstractItemModel::rowsAboutToBeInserted, this, &DosQAbstractItemModelWrapper<N, M>::beginInsertRows);
-    QObject::connect(m_impl, &QAbstractItemModel::rowsInserted, this, &DosQAbstractItemModelWrapper<N, M>::endInsertRows);
-    QObject::connect(m_impl, &QAbstractItemModel::rowsAboutToBeRemoved, this, &DosQAbstractItemModelWrapper<N, M>::beginRemoveRows);
-    QObject::connect(m_impl, &QAbstractItemModel::rowsRemoved, this, &DosQAbstractItemModelWrapper<N, M>::endRemoveRows);
-    QObject::connect(m_impl, &QAbstractItemModel::rowsAboutToBeMoved, this, &DosQAbstractItemModelWrapper<N, M>::beginMoveRows);
-    QObject::connect(m_impl, &QAbstractItemModel::rowsMoved, this, &DosQAbstractItemModelWrapper<N, M>::endMoveRows);
-    QObject::connect(m_impl, &QAbstractItemModel::columnsAboutToBeInserted, this, &DosQAbstractItemModelWrapper<N, M>::beginInsertColumns);
-    QObject::connect(m_impl, &QAbstractItemModel::columnsInserted, this, &DosQAbstractItemModelWrapper<N, M>::endInsertColumns);
-    QObject::connect(m_impl, &QAbstractItemModel::columnsAboutToBeRemoved, this, &DosQAbstractItemModelWrapper<N, M>::beginRemoveColumns);
-    QObject::connect(m_impl, &QAbstractItemModel::columnsRemoved, this, &DosQAbstractItemModelWrapper<N, M>::endRemoveColumns);
-    QObject::connect(m_impl, &QAbstractItemModel::columnsAboutToBeMoved, this, &DosQAbstractItemModelWrapper<N, M>::beginMoveColumns);
-    QObject::connect(m_impl, &QAbstractItemModel::columnsMoved, this, &DosQAbstractItemModelWrapper<N, M>::endMoveColumns);
-    QObject::connect(m_impl, &QAbstractItemModel::modelAboutToBeReset, this, &DosQAbstractItemModelWrapper<N, M>::beginResetModel);
-    QObject::connect(m_impl, &QAbstractItemModel::modelReset, this, &DosQAbstractItemModelWrapper<N, M>::endResetModel);
-    QObject::connect(m_impl, &QAbstractItemModel::dataChanged, this, &DosQAbstractItemModelWrapper<N, M>::dataChanged);
-    QObject::connect(m_impl, &QAbstractItemModel::layoutAboutToBeChanged, this, &DosQAbstractItemModelWrapper<N, M>::layoutAboutToBeChanged);
-    QObject::connect(m_impl, &QAbstractItemModel::layoutChanged, this, &DosQAbstractItemModelWrapper<N, M>::layoutChanged);
-    endResetModel();
+    QObject::connect(m_impl, &T::rowsAboutToBeInserted, this, &DosQAbstractItemModelWrapper<T, N, M>::beginInsertRows);
+    QObject::connect(m_impl, &T::rowsInserted, this, &DosQAbstractItemModelWrapper<T, N, M>::endInsertRows);
+    QObject::connect(m_impl, &T::rowsAboutToBeRemoved, this, &DosQAbstractItemModelWrapper<T, N, M>::beginRemoveRows);
+    QObject::connect(m_impl, &T::rowsRemoved, this, &DosQAbstractItemModelWrapper<T, N, M>::endRemoveRows);
+    QObject::connect(m_impl, &T::rowsAboutToBeMoved, this, &DosQAbstractItemModelWrapper<T, N, M>::beginMoveRows);
+    QObject::connect(m_impl, &T::rowsMoved, this, &DosQAbstractItemModelWrapper<T, N, M>::endMoveRows);
+    QObject::connect(m_impl, &T::columnsAboutToBeInserted, this, &DosQAbstractItemModelWrapper<T, N, M>::beginInsertColumns);
+    QObject::connect(m_impl, &T::columnsInserted, this, &DosQAbstractItemModelWrapper<T, N, M>::endInsertColumns);
+    QObject::connect(m_impl, &T::columnsAboutToBeRemoved, this, &DosQAbstractItemModelWrapper<T, N, M>::beginRemoveColumns);
+    QObject::connect(m_impl, &T::columnsRemoved, this, &DosQAbstractItemModelWrapper<T, N, M>::endRemoveColumns);
+    QObject::connect(m_impl, &T::columnsAboutToBeMoved, this, &DosQAbstractItemModelWrapper<T, N, M>::beginMoveColumns);
+    QObject::connect(m_impl, &T::columnsMoved, this, &DosQAbstractItemModelWrapper<T, N, M>::endMoveColumns);
+    QObject::connect(m_impl, &T::modelAboutToBeReset, this, &DosQAbstractItemModelWrapper<T, N, M>::beginResetModel);
+    QObject::connect(m_impl, &T::modelReset, this, &DosQAbstractItemModelWrapper<T, N, M>::endResetModel);
+    QObject::connect(m_impl, &T::dataChanged, this, &DosQAbstractItemModelWrapper<T, N, M>::dataChanged);
+    QObject::connect(m_impl, &T::layoutAboutToBeChanged, this, &DosQAbstractItemModelWrapper<T, N, M>::layoutAboutToBeChanged);
+    QObject::connect(m_impl, &T::layoutChanged, this, &DosQAbstractItemModelWrapper<T, N, M>::layoutChanged);
     Q_ASSERT(m_dObject);
     Q_ASSERT(m_impl);
 }
 
-template<int N, int M>
-DosQAbstractItemModelWrapper<N, M>::~DosQAbstractItemModelWrapper()
+template<typename T, int N, int M>
+DosQAbstractItemModelWrapper<T, N, M>::~DosQAbstractItemModelWrapper()
 {
     m_data.deleteDObject(m_id, m_dObject);
     m_dObject = nullptr;
@@ -140,206 +140,194 @@ DosQAbstractItemModelWrapper<N, M>::~DosQAbstractItemModelWrapper()
     m_impl = nullptr;
 }
 
-template<int N, int M>
-const QMetaObject *DosQAbstractItemModelWrapper<N, M>::metaObject() const
+template<typename T, int N, int M>
+const QMetaObject *DosQAbstractItemModelWrapper<T, N, M>::metaObject() const
 {
     Q_ASSERT(m_impl);
     return m_impl->metaObject();
 }
 
-template<int N, int M>
-int DosQAbstractItemModelWrapper<N, M>::qt_metacall(QMetaObject::Call call, int index, void **args)
+template<typename T, int N, int M>
+int DosQAbstractItemModelWrapper<T, N, M>::qt_metacall(QMetaObject::Call call, int index, void **args)
 {
     Q_ASSERT(m_impl);
     return m_impl->qt_metacall(call, index, args);
 }
 
-template<int N, int M>
-bool DosQAbstractItemModelWrapper<N, M>::emitSignal(QObject *emitter, const QString &name, const std::vector<QVariant> &argumentsValues)
+template<typename T, int N, int M>
+bool DosQAbstractItemModelWrapper<T, N, M>::emitSignal(QObject */*emitter*/, const QString &name, const std::vector<QVariant> &argumentsValues)
 {
     Q_ASSERT(m_impl);
     return dynamic_cast<DosIQObjectImpl *>(this)->emitSignal(this, name, argumentsValues);
 }
 
-template<int N, int M>
-void DosQAbstractItemModelWrapper<N, M>::setQmlRegisterType(QmlRegisterType data)
+template<typename T, int N, int M>
+void DosQAbstractItemModelWrapper<T, N, M>::setQmlRegisterType(QmlRegisterType data)
 {
     m_data = std::move(data);
 }
 
-template<int N, int M>
-void DosQAbstractItemModelWrapper<N, M>::setStaticMetaObject(const QMetaObject &metaObject)
+template<typename T, int N, int M>
+void DosQAbstractItemModelWrapper<T, N, M>::setStaticMetaObject(const QMetaObject &metaObject)
 {
     *(const_cast<QMetaObject *>(&staticMetaObject)) = metaObject;
 }
 
-template<int N, int M>
-void DosQAbstractItemModelWrapper<N, M>::setId(int id)
+template<typename T, int N, int M>
+void DosQAbstractItemModelWrapper<T, N, M>::setId(int id)
 {
     m_id = id;
 }
 
-template<int N, int M>
-int DosQAbstractItemModelWrapper<N, M>::rowCount(const QModelIndex &parent) const
+template<typename T, int N, int M>
+int DosQAbstractItemModelWrapper<T, N, M>::rowCount(const QModelIndex &parent) const
 {
     Q_ASSERT(m_impl);
     return m_impl->rowCount(parent);
 }
 
-template<int N, int M>
-int DosQAbstractItemModelWrapper<N, M>::columnCount(const QModelIndex &parent) const
+template<typename T, int N, int M>
+int DosQAbstractItemModelWrapper<T, N, M>::columnCount(const QModelIndex &parent) const
 {
     Q_ASSERT(m_impl);
     return m_impl->columnCount(parent);
 }
 
-template<int N, int M>
-QVariant DosQAbstractItemModelWrapper<N, M>::data(const QModelIndex &index, int role) const
+template<typename T, int N, int M>
+QVariant DosQAbstractItemModelWrapper<T, N, M>::data(const QModelIndex &index, int role) const
 {
     Q_ASSERT(m_impl);
     return m_impl->data(index, role);
 }
 
-template<int N, int M>
-bool DosQAbstractItemModelWrapper<N, M>::setData(const QModelIndex &index, const QVariant &value, int role)
+template<typename T, int N, int M>
+bool DosQAbstractItemModelWrapper<T, N, M>::setData(const QModelIndex &index, const QVariant &value, int role)
 {
     Q_ASSERT(m_impl);
     return m_impl->setData(index, value, role);
 }
 
-template<int N, int M>
-Qt::ItemFlags DosQAbstractItemModelWrapper<N, M>::flags(const QModelIndex &index) const
+template<typename T, int N, int M>
+Qt::ItemFlags DosQAbstractItemModelWrapper<T, N, M>::flags(const QModelIndex &index) const
 {
     Q_ASSERT(m_impl);
     return m_impl->flags(index);
 }
 
-template<int N, int M>
-QVariant DosQAbstractItemModelWrapper<N, M>::headerData(int section, Qt::Orientation orientation, int role) const
+template<typename T, int N, int M>
+QVariant DosQAbstractItemModelWrapper<T, N, M>::headerData(int section, Qt::Orientation orientation, int role) const
 {
     Q_ASSERT(m_impl);
     return m_impl->headerData(section, orientation, role);
 }
 
-template<int N, int M>
-QHash<int, QByteArray> DosQAbstractItemModelWrapper<N, M>::roleNames() const
+template<typename T, int N, int M>
+QHash<int, QByteArray> DosQAbstractItemModelWrapper<T, N, M>::roleNames() const
 {
     Q_ASSERT(m_impl);
     return m_impl->roleNames();
 }
 
-template<int N, int M>
-QModelIndex DosQAbstractItemModelWrapper<N, M>::index(int row, int column, const QModelIndex &parent) const
+template<typename T, int N, int M>
+QModelIndex DosQAbstractItemModelWrapper<T, N, M>::index(int row, int column, const QModelIndex &parent) const
 {
     Q_ASSERT(m_impl);
     return m_impl->index(row, column, parent);
 }
 
-template<int N, int M>
-QModelIndex DosQAbstractItemModelWrapper<N, M>::parent(const QModelIndex &child) const
+template<typename T, int N, int M>
+QModelIndex DosQAbstractItemModelWrapper<T, N, M>::parent(const QModelIndex &child) const
 {
     Q_ASSERT(m_impl);
     return m_impl->parent(child);
 }
 
-template<int N, int M>
-const QmlRegisterType &DosQAbstractItemModelWrapper<N, M>::qmlRegisterType()
+template<typename T, int N, int M>
+const QmlRegisterType &DosQAbstractItemModelWrapper<T, N, M>::qmlRegisterType()
 {
     return m_data;
 }
 
 namespace DQAIMW {
 
-template<int N>
-using RegisterTypeQObject = DosQAbstractItemModelWrapper<N, 0>;
+template<typename T, int N>
+using RegisterTypeQObject = DosQAbstractItemModelWrapper<T, N, 0>;
 
-template<int N>
+template<typename T, int N>
 int dosQmlRegisterType(QmlRegisterType args)
 {
-    RegisterTypeQObject<N>::setQmlRegisterType(std::move(args));
-    const QmlRegisterType &type = RegisterTypeQObject<N>::qmlRegisterType();
-    RegisterTypeQObject<N>::setStaticMetaObject(*(type.staticMetaObject->metaObject()));
-    int result = qmlRegisterType<RegisterTypeQObject<N>>(type.uri.c_str(), type.major, type.minor, type.qml.c_str());
-    RegisterTypeQObject<N>::setId(result);
+    RegisterTypeQObject<T, N>::setQmlRegisterType(std::move(args));
+    const QmlRegisterType &type = RegisterTypeQObject<T, N>::qmlRegisterType();
+    RegisterTypeQObject<T, N>::setStaticMetaObject(*(type.staticMetaObject->metaObject()));
+    int result = qmlRegisterType<RegisterTypeQObject<T, N>>(type.uri.c_str(), type.major, type.minor, type.qml.c_str());
+    RegisterTypeQObject<T, N>::setId(result);
     return result;
 }
 
-template<int N>
+template<typename T, int N>
 struct DosQmlRegisterHelper {
     static int Register(int i, QmlRegisterType args)
     {
         if (i > N)
             return -1;
         else if (i == N)
-            return dosQmlRegisterType<N>(std::move(args));
+            return dosQmlRegisterType<T, N>(std::move(args));
         else
-            return DosQmlRegisterHelper < N - 1 >::Register(i, std::move(args));
+            return DosQmlRegisterHelper <T, N - 1>::Register(i, std::move(args));
     }
 };
 
-template<>
-struct DosQmlRegisterHelper<0> {
+template<typename T>
+struct DosQmlRegisterHelper<T, 0> {
     static int Register(int i, QmlRegisterType args)
     {
-        return i == 0 ? dosQmlRegisterType<0>(std::move(args)) : -1;
+        return i == 0 ? dosQmlRegisterType<T, 0>(std::move(args)) : -1;
     }
 };
 
-int dosQmlRegisterType(QmlRegisterType args)
+template<typename T, int N>
+using RegisterSingletonTypeQObject = DosQAbstractItemModelWrapper<T, N, 1>;
+
+template<typename T, int N>
+QObject *singletontype_provider(QQmlEngine */*engine*/, QJSEngine */*scriptEngine*/)
 {
-    static int i = 0;
-    return DosQmlRegisterHelper<35>::Register(i++, std::move(args));
+    return new RegisterSingletonTypeQObject<T, N>();
 }
 
-template<int N>
-using RegisterSingletonTypeQObject = DosQAbstractItemModelWrapper<N, 1>;
-
-template<int N>
-QObject *singletontype_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
-{
-    return new RegisterSingletonTypeQObject<N>();
-}
-
-template<int N>
+template<typename T, int N>
 int dosQmlRegisterSingletonType(QmlRegisterType args)
 {
     using Func = QObject * (*)(QQmlEngine *, QJSEngine *);
-    Func f = singletontype_provider<N>;
+    Func f = singletontype_provider<T, N>;
 
-    RegisterSingletonTypeQObject<N>::setQmlRegisterType(std::move(args));
-    const QmlRegisterType &type = RegisterSingletonTypeQObject<N>::qmlRegisterType();
-    RegisterSingletonTypeQObject<N>::setStaticMetaObject(*(type.staticMetaObject->metaObject()));
-    int result = qmlRegisterSingletonType<RegisterSingletonTypeQObject<N>>(type.uri.c_str(), type.major, type.minor, type.qml.c_str(), f);
-    RegisterSingletonTypeQObject<N>::setId(result);
+    RegisterSingletonTypeQObject<T, N>::setQmlRegisterType(std::move(args));
+    const QmlRegisterType &type = RegisterSingletonTypeQObject<T, N>::qmlRegisterType();
+    RegisterSingletonTypeQObject<T, N>::setStaticMetaObject(*(type.staticMetaObject->metaObject()));
+    int result = qmlRegisterSingletonType<RegisterSingletonTypeQObject<T, N>>(type.uri.c_str(), type.major, type.minor, type.qml.c_str(), f);
+    RegisterSingletonTypeQObject<T, N>::setId(result);
     return result;
 }
 
-template<int N>
+template<typename T, int N>
 struct DosQmlRegisterSingletonHelper {
     static int Register(int i, QmlRegisterType args)
     {
         if (i > N)
             return -1;
         else if (i == N)
-            return dosQmlRegisterSingletonType<N>(std::move(args));
+            return dosQmlRegisterSingletonType<T, N>(std::move(args));
         else
-            return DosQmlRegisterSingletonHelper < N - 1 >::Register(i, std::move(args));
+            return DosQmlRegisterSingletonHelper <T, N - 1>::Register(i, std::move(args));
     }
 };
 
-template<>
-struct DosQmlRegisterSingletonHelper<0> {
+template<typename T>
+struct DosQmlRegisterSingletonHelper<T, 0> {
     static int Register(int i, QmlRegisterType args)
     {
-        return i == 0 ? dosQmlRegisterSingletonType<0>(std::move(args)) : -1;
+        return i == 0 ? dosQmlRegisterSingletonType<T, 0>(std::move(args)) : -1;
     }
 };
-
-int dosQmlRegisterSingletonType(QmlRegisterType args)
-{
-    static int i = 0;
-    return DosQmlRegisterSingletonHelper<35>::Register(i++, std::move(args));
-}
 
 }
 }

--- a/lib/include/DOtherSide/DosQObjectWrapper.h
+++ b/lib/include/DOtherSide/DosQObjectWrapper.h
@@ -104,7 +104,7 @@ int DosQObjectWrapper<N, M>::qt_metacall(QMetaObject::Call call, int index, void
 }
 
 template<int N, int M>
-bool DosQObjectWrapper<N, M>::emitSignal(QObject *emitter, const QString &name, const std::vector<QVariant> &argumentsValues)
+bool DosQObjectWrapper<N, M>::emitSignal(QObject */*emitter*/, const QString &name, const std::vector<QVariant> &argumentsValues)
 {
     Q_ASSERT(m_impl);
     return m_impl->emitSignal(this, name, argumentsValues);
@@ -175,7 +175,7 @@ template<int N>
 using RegisterSingletonTypeQObject = DosQObjectWrapper<N, 1>;
 
 template<int N>
-QObject *singletontype_provider(QQmlEngine *engine, QJSEngine *scriptEngine)
+QObject *singletontype_provider(QQmlEngine */*engine*/, QJSEngine */*scriptEngine*/)
 {
     return new RegisterSingletonTypeQObject<N>();
 }

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -801,19 +801,15 @@ bool dos_qmetaobject_invoke_method(DosQObject *context, DosQMetaObjectInvokeMeth
 DosQModelIndex *dos_qabstracttablemodel_index(DosQAbstractTableModel *vptr, int row, int column, DosQModelIndex *dosParent)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosQAbstractTableModel *>(object);
+    auto model = dynamic_cast<QAbstractTableModel *>(object);
     auto parent = static_cast<QModelIndex *>(dosParent);
-    auto result = new QModelIndex(model->defaultIndex(row, column, *parent));
+    auto result = new QModelIndex(model->QAbstractTableModel::index(row, column, *parent));
     return static_cast<DosQModelIndex *>(result);
 }
 
-DosQModelIndex *dos_qabstracttablemodel_parent(DosQAbstractTableModel *vptr, DosQModelIndex *dosChild)
+DosQModelIndex *dos_qabstracttablemodel_parent(DosQAbstractTableModel */*vptr*/, DosQModelIndex */*dosChild*/)
 {
-    auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosQAbstractTableModel *>(object);
-    auto child = static_cast<QModelIndex *>(dosChild);
-    auto result = new QModelIndex(model->defaultParent(*child));
-    return static_cast<DosQModelIndex *>(result);
+    return static_cast<DosQModelIndex *>(new QModelIndex());
 }
 
 ::DosQMetaObject *dos_qabstractlistmodel_qmetaobject()
@@ -838,27 +834,21 @@ DosQModelIndex *dos_qabstracttablemodel_parent(DosQAbstractTableModel *vptr, Dos
 DosQModelIndex *dos_qabstractlistmodel_index(DosQAbstractListModel *vptr, int row, int column, DosQModelIndex *dosParent)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosQAbstractListModel *>(object);
+    auto model = dynamic_cast<QAbstractListModel *>(object);
     auto parent = static_cast<QModelIndex *>(dosParent);
-    auto result = new QModelIndex(model->defaultIndex(row, column, *parent));
+    auto result = new QModelIndex(model->QAbstractListModel::index(row, column, *parent));
     return static_cast<DosQModelIndex *>(result);
 }
 
-DosQModelIndex *dos_qabstractlistmodel_parent(DosQAbstractListModel *vptr, DosQModelIndex *dosChild)
+DosQModelIndex *dos_qabstractlistmodel_parent(DosQAbstractListModel */*vptr*/, DosQModelIndex */*dosChild*/)
 {
-    auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosQAbstractListModel *>(object);
-    auto child = static_cast<QModelIndex *>(dosChild);
-    auto result = new QModelIndex(model->defaultParent(*child));
-    return static_cast<DosQModelIndex *>(result);
+    return static_cast<DosQModelIndex *>(new QModelIndex());
 }
 
-int dos_qabstractlistmodel_columnCount(DosQAbstractListModel *vptr, DosQModelIndex *dosParent)
+int dos_qabstractlistmodel_columnCount(DosQAbstractListModel */*vptr*/, DosQModelIndex *dosParent)
 {
-    auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosQAbstractListModel *>(object);
     auto parent = static_cast<QModelIndex *>(dosParent);
-    return model->defaultColumnCount(*parent);
+    return parent->isValid() ? 0 : 1;
 }
 
 ::DosQMetaObject *dos_qabstractitemmodel_qmetaobject()
@@ -970,54 +960,52 @@ void dos_qabstractitemmodel_dataChanged(::DosQAbstractItemModel *vptr,
     model->publicDataChanged(*topLeft, *bottomRight, roles);
 }
 
-DosQModelIndex *dos_qabstractitemmodel_createIndex(::DosQAbstractItemModel *vptr,
-                                                   int row, int column, void *data)
+DosQModelIndex *dos_qabstractitemmodel_createIndex(::DosQAbstractItemModel *vptr, int row, int column, void *data)
 {
     auto object = static_cast<QObject *>(vptr);
     auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
     return new QModelIndex(model->publicCreateIndex(row, column, data));
 }
 
-bool dos_qabstractitemmodel_setData(DosQAbstractItemModel *vptr,
-                                    DosQModelIndex *dosIndex, DosQVariant *dosValue, int role)
+bool dos_qabstractitemmodel_setData(DosQAbstractItemModel *vptr, DosQModelIndex *dosIndex, DosQVariant *dosValue, int role)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
+    auto model = dynamic_cast<QAbstractItemModel*>(object);
     auto index = static_cast<QModelIndex *>(dosIndex);
     auto value = static_cast<QVariant *>(dosValue);
-    return model->defaultSetData(*index, *value, role);
+    return model->QAbstractItemModel::setData(*index, *value, role);
 }
 
 DosQHashIntQByteArray *dos_qabstractitemmodel_roleNames(DosQAbstractItemModel *vptr)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
-    auto result = new QHash<int, QByteArray>(model->defaultRoleNames());
+    auto model = dynamic_cast<QAbstractItemModel*>(object);
+    auto result = new QHash<int, QByteArray>(model->QAbstractItemModel::roleNames());
     return static_cast<DosQHashIntQByteArray *>(result);
 }
 
 int dos_qabstractitemmodel_flags(DosQAbstractItemModel *vptr, DosQModelIndex *dosIndex)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
+    auto model = dynamic_cast<QAbstractItemModel*>(object);
     auto index = static_cast<QModelIndex *>(dosIndex);
-    return static_cast<int>(model->defaultFlags(*index));
+    return static_cast<int>(model->QAbstractItemModel::flags(*index));
 }
 
 DosQVariant *dos_qabstractitemmodel_headerData(DosQAbstractItemModel *vptr, int section, int orientation, int role)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
-    auto result = new QVariant(model->defaultHeaderData(section, static_cast<Qt::Orientation>(orientation), role));
+    auto model = dynamic_cast<QAbstractItemModel *>(object);
+    auto result = new QVariant(model->QAbstractItemModel::headerData(section, static_cast<Qt::Orientation>(orientation), role));
     return static_cast<DosQVariant *>(result);
 }
 
 bool dos_qabstractitemmodel_hasChildren(DosQAbstractItemModel *vptr, DosQModelIndex *dosParentIndex)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
+    auto model = dynamic_cast<QAbstractItemModel*>(object);
     auto parentIndex = static_cast<QModelIndex *>(dosParentIndex);
-    return model->defaultHasChildren(*parentIndex);
+    return model->QAbstractItemModel::hasChildren(*parentIndex);
 }
 
 bool dos_qabstractitemmodel_hasIndex(DosQAbstractItemModel *vptr, int row, int column, DosQModelIndex *dosParentIndex)
@@ -1031,17 +1019,17 @@ bool dos_qabstractitemmodel_hasIndex(DosQAbstractItemModel *vptr, int row, int c
 bool dos_qabstractitemmodel_canFetchMore(DosQAbstractItemModel *vptr, DosQModelIndex *dosParentIndex)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
+    auto model = dynamic_cast<QAbstractItemModel*>(object);
     auto parentIndex = static_cast<QModelIndex *>(dosParentIndex);
-    return model->defaultCanFetchMore(*parentIndex);
+    return model->QAbstractItemModel::canFetchMore(*parentIndex);
 }
 
 void dos_qabstractitemmodel_fetchMore(DosQAbstractItemModel *vptr, DosQModelIndex *dosParentIndex)
 {
     auto object = static_cast<QObject *>(vptr);
-    auto model = dynamic_cast<DOS::DosIQAbstractItemModelImpl *>(object);
+    auto model = dynamic_cast<QAbstractItemModel*>(object);
     auto parentIndex = static_cast<QModelIndex *>(dosParentIndex);
-    model->defaultFetchMore(*parentIndex);
+    model->QAbstractItemModel::fetchMore(*parentIndex);
 }
 
 int dos_qdeclarative_qmlregistertype(const ::QmlRegisterType *cArgs)

--- a/lib/src/DosQAbstractItemModel.cpp
+++ b/lib/src/DosQAbstractItemModel.cpp
@@ -215,30 +215,6 @@ QModelIndex DosQAbstractGenericModel<T>::publicCreateIndex(int row, int column, 
 }
 
 template<class T>
-Qt::ItemFlags DosQAbstractGenericModel<T>::defaultFlags(const QModelIndex &index) const
-{
-    return T::flags(index);
-}
-
-template<class T>
-QVariant DosQAbstractGenericModel<T>::defaultHeaderData(int section, Qt::Orientation orientation, int role) const
-{
-    return T::headerData(section, orientation, role);
-}
-
-template<class T>
-QHash<int, QByteArray> DosQAbstractGenericModel<T>::defaultRoleNames() const
-{
-    return T::roleNames();
-}
-
-template<class T>
-bool DosQAbstractGenericModel<T>::defaultSetData(const QModelIndex &index, const QVariant &value, int role)
-{
-    return T::setData(index, value, role);
-}
-
-template<class T>
 bool DosQAbstractGenericModel<T>::hasChildren(const QModelIndex &parent) const
 {
     bool result = false;
@@ -261,63 +237,9 @@ bool DosQAbstractGenericModel<T>::canFetchMore(const QModelIndex &parent) const
 }
 
 template<class T>
-bool DosQAbstractGenericModel<T>::defaultCanFetchMore(const QModelIndex &parent) const
-{
-    return this->T::canFetchMore(parent);
-}
-
-template<class T>
 void DosQAbstractGenericModel<T>::fetchMore(const QModelIndex &parent)
 {
     m_callbacks.fetchMore(m_modelObject, &parent);
-}
-
-template<class T>
-void DosQAbstractGenericModel<T>::defaultFetchMore(const QModelIndex &parent)
-{
-    this->T::fetchMore(parent);
-}
-
-QModelIndex DosQAbstractListModel::defaultIndex(int row, int column, const QModelIndex &parent) const
-{
-    return QAbstractListModel::index(row, column, parent);
-}
-
-int DosQAbstractListModel::defaultColumnCount(const QModelIndex &parent) const
-{
-    return parent.isValid() ? 0 : 1;
-}
-
-bool DosQAbstractListModel::defaultHasChildren(const QModelIndex &parent) const
-{
-    return parent.isValid() ? false : (rowCount() > 0);
-}
-
-QModelIndex DosQAbstractListModel::defaultParent(const QModelIndex & /*child*/) const
-{
-    return QModelIndex();
-}
-
-QModelIndex DosQAbstractTableModel::defaultIndex(int row, int column, const QModelIndex &parent) const
-{
-    return hasIndex(row, column, parent) ? createIndex(row, column) : QModelIndex();
-}
-
-bool DosQAbstractTableModel::defaultHasChildren(const QModelIndex &parent) const
-{
-    if (parent.model() == this || !parent.isValid())
-        return rowCount(parent) > 0 && columnCount(parent) > 0;
-    return false;
-}
-
-QModelIndex DosQAbstractTableModel::defaultParent(const QModelIndex & /*child*/) const
-{
-    return QModelIndex();
-}
-
-bool DosQAbstractItemModel::defaultHasChildren(const QModelIndex &parent) const
-{
-    return QAbstractItemModel::hasChildren(parent);
 }
 
 } // namespace DOS

--- a/lib/src/DosQDeclarative.cpp
+++ b/lib/src/DosQDeclarative.cpp
@@ -23,11 +23,12 @@
 
 namespace DOS {
 
-bool isQAbstractItemModel(const QMetaObject *metaObject)
+template<class T>
+bool isItemModel(const QMetaObject *metaObject)
 {
     const QMetaObject *current = metaObject;
     while (current) {
-        if (&QAbstractItemModel::staticMetaObject == current)
+        if (&T::staticMetaObject == current)
             return true;
         current = current->superClass();
     }
@@ -38,8 +39,12 @@ int dosQmlRegisterType(QmlRegisterType args)
 {
     static int i = 0;
     static int j = 0;
-    if (isQAbstractItemModel(args.staticMetaObject->metaObject()))
-        return DQAIMW::DosQmlRegisterHelper<35>::Register(j++, std::move(args));
+    if (isItemModel<QAbstractListModel>(args.staticMetaObject->metaObject()))
+        return DQAIMW::DosQmlRegisterHelper<QAbstractListModel, 35>::Register(j++, std::move(args));
+    else if (isItemModel<QAbstractTableModel>(args.staticMetaObject->metaObject()))
+        return DQAIMW::DosQmlRegisterHelper<QAbstractTableModel, 35>::Register(j++, std::move(args));
+    else if (isItemModel<QAbstractItemModel>(args.staticMetaObject->metaObject()))
+        return DQAIMW::DosQmlRegisterHelper<QAbstractItemModel, 35>::Register(j++, std::move(args));
     else
         return DQOW::DosQmlRegisterHelper<35>::Register(i++, std::move(args));
 }
@@ -48,8 +53,12 @@ int dosQmlRegisterSingletonType(QmlRegisterType args)
 {
     static int i = 0;
     static int j = 0;
-    if (isQAbstractItemModel(args.staticMetaObject->metaObject()))
-        return DQAIMW::DosQmlRegisterSingletonHelper<35>::Register(j++, std::move(args));
+    if (isItemModel<QAbstractListModel>(args.staticMetaObject->metaObject()))
+        return DQAIMW::DosQmlRegisterSingletonHelper<QAbstractListModel, 35>::Register(j++, std::move(args));
+    else if (isItemModel<QAbstractTableModel>(args.staticMetaObject->metaObject()))
+        return DQAIMW::DosQmlRegisterSingletonHelper<QAbstractTableModel, 35>::Register(j++, std::move(args));
+    else if (isItemModel<QAbstractItemModel>(args.staticMetaObject->metaObject()))
+        return DQAIMW::DosQmlRegisterSingletonHelper<QAbstractItemModel, 35>::Register(j++, std::move(args));
     else
         return DQOW::DosQmlRegisterSingletonHelper<35>::Register(i++, std::move(args));
 }

--- a/lib/src/DosQMetaObject.cpp
+++ b/lib/src/DosQMetaObject.cpp
@@ -100,17 +100,17 @@ const QMetaObject *BaseDosQMetaObject::metaObject() const
     return m_metaObject;
 }
 
-QMetaMethod BaseDosQMetaObject::signal(const QString &signalName) const
+QMetaMethod BaseDosQMetaObject::signal(const QString &/*signalName*/) const
 {
     return QMetaMethod();
 }
 
-QMetaMethod BaseDosQMetaObject::readSlot(const char *propertyName) const
+QMetaMethod BaseDosQMetaObject::readSlot(const char */*propertyName*/) const
 {
     return QMetaMethod();
 }
 
-QMetaMethod BaseDosQMetaObject::writeSlot(const char *propertyName) const
+QMetaMethod BaseDosQMetaObject::writeSlot(const char */*propertyName*/) const
 {
     return QMetaMethod();
 }

--- a/lib/src/DosQQuickImageProvider.cpp
+++ b/lib/src/DosQQuickImageProvider.cpp
@@ -24,7 +24,7 @@ DosImageProvider::DosImageProvider(RequestPixmapCallback callback) : QQuickImage
 {
 }
 
-QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &requestedSize)
+QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &/*requestedSize*/)
 {
     QPixmap result;
     m_pixmap_callback(id.toLatin1().data(), &size->rwidth(), &size->rheight(), size->width(), size->height(), &result);


### PR DESCRIPTION
This was due by multiple factors. The most important is that we always registered Models as DosQAbstractItemModelWrappers that is a subclass of QAbstractItemModel. This in turn broke the APIs when the user really instantiated a QAbstractTableModel from the binded language because the cast from DosQAsbstratItemModelWrapper to QAbstractTableModel failed.
The solution is to add different correct subclasses during registration