### PR TITLE
Use QDir to join paths

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -127,7 +127,8 @@ void dos_qapplication_quit()
 void dos_qqmlapplicationengine_load(::DosQQmlApplicationEngine *vptr, const char *filename)
 {
     auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-    engine->load(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + QDir::separator() + QString(filename)));
+    QDir dir(QCoreApplication::applicationDirPath());
+    engine->load(QUrl::fromLocalFile(dir.relativeFilePath(QString(filename))));
 }
 
 void dos_qqmlapplicationengine_load_url(::DosQQmlApplicationEngine *vptr, ::DosQUrl *url)


### PR DESCRIPTION
When I use Golang to call this library, running the code with go run generates an executable file in a temporary directory. In this case, the QML file cannot be located using a relative path, and an absolute path must be provided. However, the current implementation does not support absolute paths. Using QDir can accommodate both scenarios.