### PR TITLE
Using QQmlApplicationEngine::load(QString)

### DIFF
--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -127,7 +127,7 @@ void dos_qapplication_quit()
 void dos_qqmlapplicationengine_load(::DosQQmlApplicationEngine *vptr, const char *filename)
 {
     auto engine = static_cast<QQmlApplicationEngine *>(vptr);
-    engine->load(QUrl::fromLocalFile(QCoreApplication::applicationDirPath() + QDir::separator() + QString(filename)));
+    engine->load(QString(filename));
 }
 
 void dos_qqmlapplicationengine_load_url(::DosQQmlApplicationEngine *vptr, ::DosQUrl *url)


### PR DESCRIPTION
Using QQmlApplicationEngine::load(QString) to support both relative and absolute paths.