### PR TITLE
add QImage support and extend QQuickImageProvider implementation

### DIFF
--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -154,6 +154,11 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_delete(DosQQmlApplicationEngine 
 /// \brief Create a new QQuickImageProvider
 /// \return A new QQuickImageProvider
 /// \note The returned QQuickImageProvider should be freed by using dos_qquickimageprovider_delete(DosQQuickImageProvider*) unless the QQuickImageProvider has been bound to a QQmlApplicationEngine
+/// \deprecated dos_qquickimageprovider_create(RequestPixmapCallback) is deprecated. Please use dos_qquickimageprovider_create_qpixmap(DosRequestPixmapCallback, void *) instead.
+DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create(RequestPixmapCallback callback);
+/// \brief Create a new QQuickImageProvider
+/// \return A new QQuickImageProvider
+/// \note The returned QQuickImageProvider should be freed by using dos_qquickimageprovider_delete(DosQQuickImageProvider*) unless the QQuickImageProvider has been bound to a QQmlApplicationEngine
 DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create_qpixmap(DosRequestPixmapCallback callback, void *callbackData);
 /// \brief Create a new QQuickImageProvider
 /// \return A new QQuickImageProvider

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -186,6 +186,36 @@ DOS_API void DOS_CALL dos_qpixmap_assign(DosPixmap *vptr, const DosPixmap* other
 DOS_API bool DOS_CALL dos_qpixmap_isNull(DosPixmap *vptr);
 /// @}
 
+/// \defgroup QImage QImage
+/// \brief Functions related to the QImage class
+/// @{
+
+/// \brief Creates a null QImage
+DosQImage *dos_qimage_create(void);
+/// \brief Creates a QImage copied from another
+DosQImage *dos_qimage_create_qimage(const DosQImage *other);
+/// \brief Creates a QImage with data owned by binded language
+/// \param callback that will be called when the last copy is destroyed
+/// \param callbackData that will be passed to the callback
+/// \note It calls QImage::QImage(const uchar *data, int width, int height, qsizetype bytesPerLine, QImage::Format format, QImageCleanupFunction cleanupFunction = nullptr, void *cleanupInfo = nullptr) constructor
+DosQImage *dos_qimage_create_constdata(const unsigned char* data, int width, int height, int bytesPerLine, int format, DosQImageCleanupCallback cleanupCallback, void *callbackData);
+/// \brief Frees a QImage
+void dos_qimage_delete(DosQImage *vptr);
+/// \brief Load image data into a QImage from an image file
+void dos_qimage_load(DosQImage *vptr, const char* filepath, const char* format);
+/// \brief Load image data into a QImage from a buffer
+void dos_qimage_loadFromData(DosQImage *vptr, const unsigned char* data, unsigned int len);
+/// \brief Fill a QImage with a single color
+void dos_qimage_fill(DosQImage *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
+/// \brief Calls the QImage::operator=(const QImage&) function
+/// \param vptr The left hand side QImage
+/// \param other The right hand side QImage
+void dos_qimage_assign(DosQImage *vptr, const DosQImage *other);
+/// \brief Calls the QImage::isNull
+/// \return True if the QImage is null, false otherwise
+bool dos_qimage_isNull(DosQImage *vptr);
+/// @}
+
 
 /// \defgroup QQuickStyle QQuickStyle
 /// \brief Functions related to the QQuickStyle class

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -204,7 +204,7 @@ DOS_API DosQImage *DOS_CALL dos_qimage_create(void);
 /// \brief Creates a QImage copied from another
 DOS_API DosQImage *DOS_CALL dos_qimage_create_qimage(const DosQImage *other);
 /// \brief Creates a QImage with data owned by binded language
-/// \param callback that will be called when the last copy is destroyed
+/// \param cleanupCallback that will be called when the last copy is destroyed
 /// \param callbackData that will be passed to the callback
 /// \note It calls QImage::QImage(const uchar *data, int width, int height, qsizetype bytesPerLine, QImage::Format format, QImageCleanupFunction cleanupFunction = nullptr, void *cleanupInfo = nullptr) constructor
 DOS_API DosQImage *DOS_CALL dos_qimage_create_constdata(const unsigned char* data, int width, int height, int bytesPerLine, int format, DosQImageCleanupCallback cleanupCallback, void *callbackData);

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -195,29 +195,29 @@ DOS_API bool DOS_CALL dos_qpixmap_isNull(DosPixmap *vptr);
 /// @{
 
 /// \brief Creates a null QImage
-DosQImage *dos_qimage_create(void);
+DOS_API DosQImage *DOS_CALL dos_qimage_create(void);
 /// \brief Creates a QImage copied from another
-DosQImage *dos_qimage_create_qimage(const DosQImage *other);
+DOS_API DosQImage *DOS_CALL dos_qimage_create_qimage(const DosQImage *other);
 /// \brief Creates a QImage with data owned by binded language
 /// \param callback that will be called when the last copy is destroyed
 /// \param callbackData that will be passed to the callback
 /// \note It calls QImage::QImage(const uchar *data, int width, int height, qsizetype bytesPerLine, QImage::Format format, QImageCleanupFunction cleanupFunction = nullptr, void *cleanupInfo = nullptr) constructor
-DosQImage *dos_qimage_create_constdata(const unsigned char* data, int width, int height, int bytesPerLine, int format, DosQImageCleanupCallback cleanupCallback, void *callbackData);
+DOS_API DosQImage *DOS_CALL dos_qimage_create_constdata(const unsigned char* data, int width, int height, int bytesPerLine, int format, DosQImageCleanupCallback cleanupCallback, void *callbackData);
 /// \brief Frees a QImage
-void dos_qimage_delete(DosQImage *vptr);
+DOS_API void DOS_CALL dos_qimage_delete(DosQImage *vptr);
 /// \brief Load image data into a QImage from an image file
-void dos_qimage_load(DosQImage *vptr, const char* filepath, const char* format);
+DOS_API void DOS_CALL dos_qimage_load(DosQImage *vptr, const char* filepath, const char* format);
 /// \brief Load image data into a QImage from a buffer
-void dos_qimage_loadFromData(DosQImage *vptr, const unsigned char* data, unsigned int len);
+DOS_API void DOS_CALL dos_qimage_loadFromData(DosQImage *vptr, const unsigned char* data, unsigned int len);
 /// \brief Fill a QImage with a single color
-void dos_qimage_fill(DosQImage *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
+DOS_API void DOS_CALL dos_qimage_fill(DosQImage *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a);
 /// \brief Calls the QImage::operator=(const QImage&) function
 /// \param vptr The left hand side QImage
 /// \param other The right hand side QImage
-void dos_qimage_assign(DosQImage *vptr, const DosQImage *other);
+DOS_API void DOS_CALL dos_qimage_assign(DosQImage *vptr, const DosQImage *other);
 /// \brief Calls the QImage::isNull
 /// \return True if the QImage is null, false otherwise
-bool dos_qimage_isNull(DosQImage *vptr);
+DOS_API bool DOS_CALL dos_qimage_isNull(DosQImage *vptr);
 /// @}
 
 

--- a/lib/include/DOtherSide/DOtherSide.h
+++ b/lib/include/DOtherSide/DOtherSide.h
@@ -154,7 +154,11 @@ DOS_API void DOS_CALL dos_qqmlapplicationengine_delete(DosQQmlApplicationEngine 
 /// \brief Create a new QQuickImageProvider
 /// \return A new QQuickImageProvider
 /// \note The returned QQuickImageProvider should be freed by using dos_qquickimageprovider_delete(DosQQuickImageProvider*) unless the QQuickImageProvider has been bound to a QQmlApplicationEngine
-DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create(RequestPixmapCallback callback);
+DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create_qpixmap(DosRequestPixmapCallback callback, void *callbackData);
+/// \brief Create a new QQuickImageProvider
+/// \return A new QQuickImageProvider
+/// \note The returned QQuickImageProvider should be freed by using dos_qquickimageprovider_delete(DosQQuickImageProvider*) unless the QQuickImageProvider has been bound to a QQmlApplicationEngine
+DOS_API DosQQuickImageProvider *DOS_CALL dos_qquickimageprovider_create_qimage(DosRequestImageCallback callback, void *callbackData);
 /// \breif Frees a QQuickImageProvider
 DOS_API void DOS_CALL dos_qquickimageprovider_delete(DosQQuickImageProvider *vptr);
 /// @}

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -97,6 +97,7 @@ typedef void DosQMetaObjectConnection;
 
 /// A pixmap callback to be supplied to an image provider
 /// \param id Image source id
+/// \param callbackData callback data passed to dos_qquickimageprovider_create_qimage
 /// \param width pointer to the width of the image
 /// \param height pointer to the height of the image
 /// \param requestedHeight sourceSize.height attribute
@@ -104,7 +105,19 @@ typedef void DosQMetaObjectConnection;
 /// \param[out] result The result QPixmap. This should be assigned from the binded language
 /// \note \p id is the trailing part of an image source url for example "image://<provider_id>/<id>
 /// \note The \p result arg is an out parameter so it \b shouldn't be deleted. See the dos_qpixmap_assign
-typedef void (DOS_CALL *RequestPixmapCallback)(const char *id, int *width, int *height, int requestedWidth, int requestedHeight, DosPixmap* result);
+typedef void (DOS_CALL *DosRequestPixmapCallback)(const char *id, void *callbackData, int *width, int *height, int requestedWidth, int requestedHeight, DosPixmap* result);
+
+/// A image callback to be supplied to an image provider
+/// \param id Image source id
+/// \param callbackData callback data passed to dos_qquickimageprovider_create_qimage
+/// \param width pointer to the width of the image
+/// \param height pointer to the height of the image
+/// \param requestedHeight sourceSize.height attribute
+/// \param requestedWidth sourcesSize.width attribute
+/// \param[out] result The result QImage. This should be assigned from the binded language
+/// \note \p id is the trailing part of an image source url for example "image://<provider_id>/<id>
+/// \note The \p result arg is an out parameter so it \b shouldn't be deleted. See the dos_qimage_assign
+typedef void (DOS_CALL *DosRequestImageCallback)(const char *id, void *callbackData, int *width, int *height, int requestedWidth, int requestedHeight, DosQImage* result);
 
 /// A callback that will be called when the last copy QImage is destroyed
 typedef void (DOS_CALL *DosQImageCleanupCallback)(void *callbackData);

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -86,6 +86,9 @@ typedef void DosQQuickImageProvider;
 /// A pointer to a QPixmap
 typedef void DosPixmap;
 
+/// A pointer to a QImage
+typedef void DosQImage;
+
 /// A pointer to a QPointer
 typedef void DosQPointer;
 
@@ -102,6 +105,9 @@ typedef void DosQMetaObjectConnection;
 /// \note \p id is the trailing part of an image source url for example "image://<provider_id>/<id>
 /// \note The \p result arg is an out parameter so it \b shouldn't be deleted. See the dos_qpixmap_assign
 typedef void (DOS_CALL *RequestPixmapCallback)(const char *id, int *width, int *height, int requestedWidth, int requestedHeight, DosPixmap* result);
+
+/// A callback that will be called when the last copy QImage is destroyed
+typedef void (DOS_CALL *DosQImageCleanupCallback)(void *callbackData);
 
 /// Called when a property is readed/written or a slot should be executed
 /// \param self The pointer of QObject in the binded language

--- a/lib/include/DOtherSide/DOtherSideTypes.h
+++ b/lib/include/DOtherSide/DOtherSideTypes.h
@@ -97,6 +97,18 @@ typedef void DosQMetaObjectConnection;
 
 /// A pixmap callback to be supplied to an image provider
 /// \param id Image source id
+/// \param width pointer to the width of the image
+/// \param height pointer to the height of the image
+/// \param requestedHeight sourceSize.height attribute
+/// \param requestedWidth sourcesSize.width attribute
+/// \param[out] result The result QPixmap. This should be assigned from the binded language
+/// \note \p id is the trailing part of an image source url for example "image://<provider_id>/<id>
+/// \note The \p result arg is an out parameter so it \b shouldn't be deleted. See the dos_qpixmap_assign
+/// \deprecated RequestPixmapCallback is deprecated. See dos_qquickimageprovider_create_qpixmap(DosRequestPixmapCallback, void *).
+typedef void (DOS_CALL *RequestPixmapCallback)(const char *id, int *width, int *height, int requestedWidth, int requestedHeight, DosPixmap* result);
+
+/// A pixmap callback to be supplied to an image provider
+/// \param id Image source id
 /// \param callbackData callback data passed to dos_qquickimageprovider_create_qimage
 /// \param width pointer to the width of the image
 /// \param height pointer to the height of the image

--- a/lib/include/DOtherSide/DosQQuickImageProvider.h
+++ b/lib/include/DOtherSide/DosQQuickImageProvider.h
@@ -24,6 +24,7 @@
 
 // Qt
 #include <QtGui/QPixmap>
+#include <QtGui/QImage>
 #include <QtQuick/QQuickImageProvider>
 
 #include "DOtherSideTypes.h"
@@ -31,10 +32,12 @@
 class DosImageProvider : public QQuickImageProvider
 {
 public:
-    DosImageProvider(RequestPixmapCallback callback);
+    DosImageProvider(DosRequestPixmapCallback pixmapCallback, DosRequestImageCallback imageCallback, void *callbackData);
 
     QPixmap requestPixmap(const QString &id, QSize *size, const QSize &requestedSize) override;
-
+    QImage requestImage(const QString &id, QSize *size, const QSize &requestedSize) override;
 private:
-    RequestPixmapCallback m_pixmap_callback;
+    DosRequestPixmapCallback m_pixmap_callback;
+    DosRequestImageCallback m_image_callback;
+    void *m_callback_data;
 };

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -169,10 +169,14 @@ void dos_qqmlapplicationengine_delete(::DosQQmlApplicationEngine *vptr)
     delete engine;
 }
 
-
-::DosQQuickImageProvider *dos_qquickimageprovider_create(RequestPixmapCallback callback)
+::DosQQuickImageProvider *dos_qquickimageprovider_create_qpixmap(DosRequestPixmapCallback callback, void *callbackData)
 {
-    return new DosImageProvider(callback);
+    return new DosImageProvider(callback, nullptr, callbackData);
+}
+
+::DosQQuickImageProvider *dos_qquickimageprovider_create_qimage(DosRequestImageCallback callback, void *callbackData)
+{
+    return new DosImageProvider(nullptr, callback, callbackData);
 }
 
 void dos_qquickimageprovider_delete(::DosQQuickImageProvider *vptr)

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -169,6 +169,15 @@ void dos_qqmlapplicationengine_delete(::DosQQmlApplicationEngine *vptr)
     delete engine;
 }
 
+static void compat_requestpixmap_callback(const char *id, void *callbackData, int *width, int *height, int requestedWidth, int requestedHeight, DosPixmap* result) {
+    ((RequestPixmapCallback)(callbackData))(id, width, height, requestedWidth, requestedHeight, result);
+}
+
+::DosQQuickImageProvider *dos_qquickimageprovider_create(RequestPixmapCallback callback)
+{
+    return dos_qquickimageprovider_create_qpixmap(compat_requestpixmap_callback, (void *)(callback));
+}
+
 ::DosQQuickImageProvider *dos_qquickimageprovider_create_qpixmap(DosRequestPixmapCallback callback, void *callbackData)
 {
     return new DosImageProvider(callback, nullptr, callbackData);

--- a/lib/src/DOtherSide.cpp
+++ b/lib/src/DOtherSide.cpp
@@ -236,6 +236,61 @@ bool dos_qpixmap_isNull(DosPixmap *vptr)
     return pixmap->isNull();
 }
 
+::DosQImage *dos_qimage_create()
+{
+    return new QImage();
+}
+
+::DosQImage *dos_qimage_create_qimage(const DosQImage *other)
+{
+    auto image = static_cast<const QImage *>(other);
+    return new QImage(image ? *image : QImage());
+}
+
+::DosQImage *dos_qimage_create_constdata(const unsigned char* data, int width, int height, int bytesPerLine, int format, DosQImageCleanupCallback cleanupCallback, void *callbackData)
+{
+    return new QImage(data, width, height, bytesPerLine, static_cast<QImage::Format>(format), static_cast<QImageCleanupFunction>(cleanupCallback), callbackData);
+}
+
+void dos_qimage_delete(DosQImage *vptr)
+{
+    auto image = static_cast<QImage *>(vptr);
+    delete image;
+}
+
+void dos_qimage_load(DosQImage *vptr, const char* filepath, const char* format)
+{
+    auto image = static_cast<QImage *>(vptr);
+    image->load(QString(filepath), format);
+}
+
+void dos_qimage_loadFromData(DosQImage *vptr, const unsigned char* data, unsigned int len)
+{
+    auto image = static_cast<QImage *>(vptr);
+    image->loadFromData(data, len);
+}
+
+void dos_qimage_fill(DosQImage *vptr, unsigned char r, unsigned char g, unsigned char b, unsigned char a)
+{
+    auto image = static_cast<QImage *>(vptr);
+    image->fill(QColor(r, g, b, a));
+}
+
+void dos_qimage_assign(DosQImage *vptr, const DosQImage *other)
+{
+    if (vptr) {
+        auto lhs = static_cast<QImage *>(vptr);
+        auto rhs = static_cast<const QImage *>(other);
+        *lhs = rhs ? *rhs : QImage();
+    }
+}
+
+bool dos_qimage_isNull(DosQImage *vptr)
+{
+    auto image = static_cast<QImage *>(vptr);
+    return image->isNull();
+}
+
 ::DosQQuickView *dos_qquickview_create()
 {
     return new QQuickView();

--- a/lib/src/DosQQuickImageProvider.cpp
+++ b/lib/src/DosQQuickImageProvider.cpp
@@ -19,14 +19,22 @@
 
 #include "DOtherSide/DosQQuickImageProvider.h"
 
-DosImageProvider::DosImageProvider(RequestPixmapCallback callback) : QQuickImageProvider(QQuickImageProvider::Pixmap),
-                                                              m_pixmap_callback(callback)
+DosImageProvider::DosImageProvider(DosRequestPixmapCallback pixmapCallback, DosRequestImageCallback imageCallback, void *callbackData) :
+    QQuickImageProvider(pixmapCallback ? QQuickImageProvider::Pixmap : QQuickImageProvider::Image),
+    m_pixmap_callback(pixmapCallback), m_image_callback(imageCallback), m_callback_data(callbackData)
 {
 }
 
 QPixmap DosImageProvider::requestPixmap(const QString &id, QSize *size, const QSize &/*requestedSize*/)
 {
     QPixmap result;
-    m_pixmap_callback(id.toLatin1().data(), &size->rwidth(), &size->rheight(), size->width(), size->height(), &result);
+    m_pixmap_callback(id.toLatin1().data(), m_callback_data, &size->rwidth(), &size->rheight(), size->width(), size->height(), &result);
+    return result;
+}
+
+QImage DosImageProvider::requestImage(const QString &id, QSize *size, const QSize &/*requestedSize*/)
+{
+    QImage result;
+    m_image_callback(id.toLatin1().data(), m_callback_data, &size->rwidth(), &size->rheight(), size->width(), size->height(), &result);
     return result;
 }


### PR DESCRIPTION
- added QImage wrapper
- added the callback data parameter to the provider's create function.
- dos_qquickimageprovider_create replaced by dos_qquickimageprovider_create_qimage/qpixmap
- RequestPixmapCallback replaced by DosRequestPixmapCallback and DosRequestImageCallback